### PR TITLE
feat(docx): run-level write support, table modifications, and round-t…

### DIFF
--- a/src/DocxMcp/Helpers/ElementFactory.cs
+++ b/src/DocxMcp/Helpers/ElementFactory.cs
@@ -27,6 +27,8 @@ public static class ElementFactory
             "paragraph" => CreateParagraph(value),
             "heading" => CreateHeading(value),
             "table" => CreateTable(value),
+            "row" => CreateRowFromJson(value),
+            "cell" => CreateRichTableCell(value, false),
             "image" => CreateImage(value, mainPart),
             "hyperlink" => CreateHyperlink(value, mainPart),
             "page_break" => CreatePageBreak(),
@@ -59,6 +61,82 @@ public static class ElementFactory
         if (style.TryGetProperty("style", out var styleProp))
         {
             props.ParagraphStyleId = new ParagraphStyleId { Val = styleProp.GetString() };
+        }
+
+        // Paragraph spacing
+        if (style.TryGetProperty("spacing_before", out var spaceBefore) ||
+            style.TryGetProperty("spacing_after", out var spaceAfter) ||
+            style.TryGetProperty("line_spacing", out var lineSpacing))
+        {
+            var spacing = new SpacingBetweenLines();
+            if (style.TryGetProperty("spacing_before", out spaceBefore))
+                spacing.Before = spaceBefore.GetInt32().ToString();
+            if (style.TryGetProperty("spacing_after", out spaceAfter))
+                spacing.After = spaceAfter.GetInt32().ToString();
+            if (style.TryGetProperty("line_spacing", out lineSpacing))
+                spacing.Line = lineSpacing.GetInt32().ToString();
+            props.SpacingBetweenLines = spacing;
+        }
+
+        // Indentation
+        if (style.TryGetProperty("indent_left", out var indentLeft) ||
+            style.TryGetProperty("indent_right", out var indentRight) ||
+            style.TryGetProperty("indent_first_line", out var indentFirst) ||
+            style.TryGetProperty("indent_hanging", out var indentHanging))
+        {
+            var indent = new Indentation();
+            if (style.TryGetProperty("indent_left", out indentLeft))
+                indent.Left = indentLeft.GetInt32().ToString();
+            if (style.TryGetProperty("indent_right", out indentRight))
+                indent.Right = indentRight.GetInt32().ToString();
+            if (style.TryGetProperty("indent_first_line", out indentFirst))
+                indent.FirstLine = indentFirst.GetInt32().ToString();
+            if (style.TryGetProperty("indent_hanging", out indentHanging))
+                indent.Hanging = indentHanging.GetInt32().ToString();
+            props.Indentation = indent;
+        }
+
+        // Tab stops
+        if (style.TryGetProperty("tabs", out var tabs) && tabs.ValueKind == JsonValueKind.Array)
+        {
+            var tabsElem = new Tabs();
+            foreach (var tab in tabs.EnumerateArray())
+            {
+                var tabStop = new TabStop();
+                if (tab.TryGetProperty("position", out var pos))
+                    tabStop.Position = pos.GetInt32();
+                if (tab.TryGetProperty("alignment", out var tabAlign))
+                {
+                    tabStop.Val = tabAlign.GetString()?.ToLowerInvariant() switch
+                    {
+                        "left" => TabStopValues.Left,
+                        "center" => TabStopValues.Center,
+                        "right" => TabStopValues.Right,
+                        "decimal" => TabStopValues.Decimal,
+                        "bar" => TabStopValues.Bar,
+                        "clear" => TabStopValues.Clear,
+                        _ => TabStopValues.Left
+                    };
+                }
+                else
+                {
+                    tabStop.Val = TabStopValues.Left;
+                }
+                if (tab.TryGetProperty("leader", out var leader))
+                {
+                    tabStop.Leader = leader.GetString()?.ToLowerInvariant() switch
+                    {
+                        "dot" => TabStopLeaderCharValues.Dot,
+                        "hyphen" => TabStopLeaderCharValues.Hyphen,
+                        "underscore" => TabStopLeaderCharValues.Underscore,
+                        "heavy" => TabStopLeaderCharValues.Heavy,
+                        "middledot" => TabStopLeaderCharValues.MiddleDot,
+                        _ => TabStopLeaderCharValues.None
+                    };
+                }
+                tabsElem.AppendChild(tabStop);
+            }
+            props.Tabs = tabsElem;
         }
 
         return props;
@@ -97,25 +175,111 @@ public static class ElementFactory
             props.Color = new Color { Val = color.GetString() };
         }
 
+        if (style.TryGetProperty("highlight", out var highlight))
+        {
+            props.Highlight = new Highlight
+            {
+                Val = highlight.GetString()?.ToLowerInvariant() switch
+                {
+                    "yellow" => HighlightColorValues.Yellow,
+                    "green" => HighlightColorValues.Green,
+                    "cyan" => HighlightColorValues.Cyan,
+                    "magenta" => HighlightColorValues.Magenta,
+                    "blue" => HighlightColorValues.Blue,
+                    "red" => HighlightColorValues.Red,
+                    "dark_blue" => HighlightColorValues.DarkBlue,
+                    "dark_cyan" => HighlightColorValues.DarkCyan,
+                    "dark_green" => HighlightColorValues.DarkGreen,
+                    "dark_magenta" => HighlightColorValues.DarkMagenta,
+                    "dark_red" => HighlightColorValues.DarkRed,
+                    "dark_yellow" => HighlightColorValues.DarkYellow,
+                    "light_gray" => HighlightColorValues.LightGray,
+                    "dark_gray" => HighlightColorValues.DarkGray,
+                    "black" => HighlightColorValues.Black,
+                    _ => HighlightColorValues.Yellow
+                }
+            };
+        }
+
+        if (style.TryGetProperty("vertical_align", out var vertAlign))
+        {
+            props.VerticalTextAlignment = new VerticalTextAlignment
+            {
+                Val = vertAlign.GetString()?.ToLowerInvariant() switch
+                {
+                    "superscript" => VerticalPositionValues.Superscript,
+                    "subscript" => VerticalPositionValues.Subscript,
+                    _ => VerticalPositionValues.Baseline
+                }
+            };
+        }
+
         return props;
     }
 
-    private static Paragraph CreateParagraph(JsonElement value)
+    /// <summary>
+    /// Create a Run element from a JSON run descriptor.
+    /// Supports: text, tab, style properties.
+    /// </summary>
+    public static Run CreateRun(JsonElement runJson)
     {
-        var paragraph = new Paragraph();
+        var run = new Run();
 
-        // Apply paragraph-level style
-        if (value.TryGetProperty("style", out var style))
+        // Apply run-level style
+        if (runJson.TryGetProperty("style", out var style))
         {
-            paragraph.ParagraphProperties = CreateParagraphProperties(style);
+            run.RunProperties = CreateRunProperties(style);
         }
 
-        // Create run with text
+        // Determine content type
+        if (runJson.TryGetProperty("tab", out var tab) && tab.GetBoolean())
+        {
+            // This run is a tab character
+            run.AppendChild(new TabChar());
+        }
+        else if (runJson.TryGetProperty("break", out var brk))
+        {
+            var breakType = brk.GetString()?.ToLowerInvariant() switch
+            {
+                "line" => BreakValues.TextWrapping,
+                "page" => BreakValues.Page,
+                "column" => BreakValues.Column,
+                _ => BreakValues.TextWrapping
+            };
+            run.AppendChild(new Break { Type = breakType });
+        }
+        else
+        {
+            // Regular text run
+            var text = runJson.TryGetProperty("text", out var txt)
+                ? txt.GetString() ?? ""
+                : "";
+            run.AppendChild(new Text(text) { Space = SpaceProcessingModeValues.Preserve });
+        }
+
+        return run;
+    }
+
+    /// <summary>
+    /// Populate a paragraph with runs from a JSON runs array, or fall back to flat text.
+    /// </summary>
+    private static void PopulateRuns(Paragraph paragraph, JsonElement value)
+    {
+        // If runs array is provided, use run-level write support
+        if (value.TryGetProperty("runs", out var runs) && runs.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var runJson in runs.EnumerateArray())
+            {
+                paragraph.AppendChild(CreateRun(runJson));
+            }
+            return;
+        }
+
+        // Fall back to flat text with optional style
         if (value.TryGetProperty("text", out var text))
         {
             var run = new Run();
 
-            // Apply run-level style
             if (value.TryGetProperty("style", out var runStyle))
             {
                 run.RunProperties = CreateRunProperties(runStyle);
@@ -124,6 +288,24 @@ public static class ElementFactory
             run.AppendChild(new Text(text.GetString() ?? "") { Space = SpaceProcessingModeValues.Preserve });
             paragraph.AppendChild(run);
         }
+    }
+
+    private static Paragraph CreateParagraph(JsonElement value)
+    {
+        var paragraph = new Paragraph();
+
+        // Apply paragraph-level properties
+        if (value.TryGetProperty("properties", out var props))
+        {
+            paragraph.ParagraphProperties = CreateParagraphProperties(props);
+        }
+        else if (value.TryGetProperty("style", out var style) && !value.TryGetProperty("runs", out _))
+        {
+            // Legacy: when no runs array, "style" applies to both paragraph and run
+            paragraph.ParagraphProperties = CreateParagraphProperties(style);
+        }
+
+        PopulateRuns(paragraph, value);
 
         return paragraph;
     }
@@ -131,17 +313,34 @@ public static class ElementFactory
     private static Paragraph CreateHeading(JsonElement value)
     {
         var level = value.TryGetProperty("level", out var lvl) ? lvl.GetInt32() : 1;
-        var text = value.TryGetProperty("text", out var txt) ? txt.GetString() ?? "" : "";
 
         var paragraph = new Paragraph();
-        paragraph.ParagraphProperties = new ParagraphProperties
+
+        // Start with heading style
+        var paragraphProps = new ParagraphProperties
         {
             ParagraphStyleId = new ParagraphStyleId { Val = $"Heading{level}" }
         };
 
-        var run = new Run();
-        run.AppendChild(new Text(text) { Space = SpaceProcessingModeValues.Preserve });
-        paragraph.AppendChild(run);
+        // Merge additional paragraph properties if provided
+        if (value.TryGetProperty("properties", out var props))
+        {
+            var extraProps = CreateParagraphProperties(props);
+
+            // Copy over any properties that were explicitly set
+            if (extraProps.Justification is not null)
+                paragraphProps.Justification = (Justification)extraProps.Justification.CloneNode(true);
+            if (extraProps.SpacingBetweenLines is not null)
+                paragraphProps.SpacingBetweenLines = (SpacingBetweenLines)extraProps.SpacingBetweenLines.CloneNode(true);
+            if (extraProps.Indentation is not null)
+                paragraphProps.Indentation = (Indentation)extraProps.Indentation.CloneNode(true);
+            if (extraProps.Tabs is not null)
+                paragraphProps.Tabs = (Tabs)extraProps.Tabs.CloneNode(true);
+        }
+
+        paragraph.ParagraphProperties = paragraphProps;
+
+        PopulateRuns(paragraph, value);
 
         return paragraph;
     }
@@ -151,49 +350,27 @@ public static class ElementFactory
         var table = new Table();
 
         // Table properties with borders
-        var tblProps = new TableProperties();
-        var borderStyle = value.TryGetProperty("border_style", out var bs)
-            ? bs.GetString() ?? "single"
-            : "single";
-
-        if (borderStyle != "none")
-        {
-            var borderValue = borderStyle switch
-            {
-                "single" => BorderValues.Single,
-                "double" => BorderValues.Double,
-                "dashed" => BorderValues.Dashed,
-                "dotted" => BorderValues.Dotted,
-                _ => BorderValues.Single
-            };
-
-            tblProps.TableBorders = new TableBorders(
-                new TopBorder { Val = borderValue, Size = 4 },
-                new BottomBorder { Val = borderValue, Size = 4 },
-                new LeftBorder { Val = borderValue, Size = 4 },
-                new RightBorder { Val = borderValue, Size = 4 },
-                new InsideHorizontalBorder { Val = borderValue, Size = 4 },
-                new InsideVerticalBorder { Val = borderValue, Size = 4 }
-            );
-        }
-
+        var tblProps = CreateTableProperties(value);
         table.AppendChild(tblProps);
+
+        // Table grid (column definitions)
+        if (value.TryGetProperty("columns", out var columns) && columns.ValueKind == JsonValueKind.Array)
+        {
+            var grid = new TableGrid();
+            foreach (var col in columns.EnumerateArray())
+            {
+                var gridCol = new GridColumn();
+                if (col.TryGetProperty("width", out var w))
+                    gridCol.Width = w.GetInt32().ToString();
+                grid.AppendChild(gridCol);
+            }
+            table.AppendChild(grid);
+        }
 
         // Headers row
         if (value.TryGetProperty("headers", out var headers) && headers.ValueKind == JsonValueKind.Array)
         {
-            var headerRow = new TableRow();
-            foreach (var cell in headers.EnumerateArray())
-            {
-                var tc = new TableCell();
-                var p = new Paragraph();
-                var r = new Run();
-                r.RunProperties = new RunProperties { Bold = new Bold() };
-                r.AppendChild(new Text(cell.GetString() ?? "") { Space = SpaceProcessingModeValues.Preserve });
-                p.AppendChild(r);
-                tc.AppendChild(p);
-                headerRow.AppendChild(tc);
-            }
+            var headerRow = CreateTableRow(headers, isHeader: true);
             table.AppendChild(headerRow);
         }
 
@@ -202,25 +379,347 @@ public static class ElementFactory
         {
             foreach (var row in rows.EnumerateArray())
             {
-                var tableRow = new TableRow();
                 if (row.ValueKind == JsonValueKind.Array)
                 {
-                    foreach (var cell in row.EnumerateArray())
-                    {
-                        var tc = new TableCell();
-                        var p = new Paragraph();
-                        var r = new Run();
-                        r.AppendChild(new Text(cell.GetString() ?? cell.ToString()) { Space = SpaceProcessingModeValues.Preserve });
-                        p.AppendChild(r);
-                        tc.AppendChild(p);
-                        tableRow.AppendChild(tc);
-                    }
+                    // Simple string array row
+                    var tableRow = CreateTableRow(row, isHeader: false);
+                    table.AppendChild(tableRow);
                 }
-                table.AppendChild(tableRow);
+                else if (row.ValueKind == JsonValueKind.Object)
+                {
+                    // Rich row object with cells array
+                    var tableRow = CreateRichTableRow(row);
+                    table.AppendChild(tableRow);
+                }
             }
         }
 
         return table;
+    }
+
+    /// <summary>
+    /// Create table properties from a JSON value.
+    /// </summary>
+    public static TableProperties CreateTableProperties(JsonElement value)
+    {
+        var tblProps = new TableProperties();
+        var borderStyle = value.TryGetProperty("border_style", out var bs)
+            ? bs.GetString() ?? "single"
+            : "single";
+
+        if (borderStyle != "none")
+        {
+            var borderValue = ParseBorderValue(borderStyle);
+            var borderSize = value.TryGetProperty("border_size", out var bsz)
+                ? (uint)bsz.GetInt32()
+                : 4u;
+
+            tblProps.TableBorders = new TableBorders(
+                new TopBorder { Val = borderValue, Size = borderSize },
+                new BottomBorder { Val = borderValue, Size = borderSize },
+                new LeftBorder { Val = borderValue, Size = borderSize },
+                new RightBorder { Val = borderValue, Size = borderSize },
+                new InsideHorizontalBorder { Val = borderValue, Size = borderSize },
+                new InsideVerticalBorder { Val = borderValue, Size = borderSize }
+            );
+        }
+
+        // Table width
+        if (value.TryGetProperty("width", out var width))
+        {
+            var widthType = value.TryGetProperty("width_type", out var wt)
+                ? wt.GetString()?.ToLowerInvariant() switch
+                {
+                    "pct" => TableWidthUnitValues.Pct,
+                    "dxa" => TableWidthUnitValues.Dxa,
+                    "auto" => TableWidthUnitValues.Auto,
+                    _ => TableWidthUnitValues.Dxa
+                }
+                : TableWidthUnitValues.Dxa;
+
+            tblProps.TableWidth = new TableWidth
+            {
+                Width = width.GetInt32().ToString(),
+                Type = widthType
+            };
+        }
+
+        // Table style
+        if (value.TryGetProperty("table_style", out var tableStyle))
+        {
+            tblProps.TableStyle = new TableStyle { Val = tableStyle.GetString() };
+        }
+
+        // Table alignment
+        if (value.TryGetProperty("table_alignment", out var tblAlign))
+        {
+            tblProps.TableJustification = new TableJustification
+            {
+                Val = tblAlign.GetString()?.ToLowerInvariant() switch
+                {
+                    "left" => TableRowAlignmentValues.Left,
+                    "center" => TableRowAlignmentValues.Center,
+                    "right" => TableRowAlignmentValues.Right,
+                    _ => TableRowAlignmentValues.Left
+                }
+            };
+        }
+
+        return tblProps;
+    }
+
+    /// <summary>
+    /// Create a table row from a JSON array of cell values (strings or rich objects).
+    /// </summary>
+    private static TableRow CreateTableRow(JsonElement cells, bool isHeader)
+    {
+        var tableRow = new TableRow();
+
+        if (isHeader)
+        {
+            // Mark as header row (repeats on page breaks)
+            tableRow.TableRowProperties = new TableRowProperties(
+                new TableHeader());
+        }
+
+        foreach (var cell in cells.EnumerateArray())
+        {
+            if (cell.ValueKind == JsonValueKind.Object)
+            {
+                tableRow.AppendChild(CreateRichTableCell(cell, isHeader));
+            }
+            else
+            {
+                // Simple string cell
+                var tc = new TableCell();
+                var p = new Paragraph();
+                var r = new Run();
+                if (isHeader)
+                    r.RunProperties = new RunProperties { Bold = new Bold() };
+                r.AppendChild(new Text(cell.GetString() ?? cell.ToString())
+                    { Space = SpaceProcessingModeValues.Preserve });
+                p.AppendChild(r);
+                tc.AppendChild(p);
+                tableRow.AppendChild(tc);
+            }
+        }
+
+        return tableRow;
+    }
+
+    /// <summary>
+    /// Create a table row from a JSON value (for use as top-level type in patches).
+    /// Accepts: {"type": "row", "cells": [...], "height": N, "is_header": bool}
+    /// </summary>
+    private static TableRow CreateRowFromJson(JsonElement value)
+    {
+        return CreateRichTableRow(value);
+    }
+
+    /// <summary>
+    /// Create a table row from a rich JSON object with "cells" array and optional row properties.
+    /// </summary>
+    private static TableRow CreateRichTableRow(JsonElement rowJson)
+    {
+        var tableRow = new TableRow();
+
+        // Row properties
+        if (rowJson.TryGetProperty("height", out var height))
+        {
+            tableRow.TableRowProperties = new TableRowProperties(
+                new TableRowHeight { Val = (uint)height.GetInt32() });
+        }
+
+        if (rowJson.TryGetProperty("is_header", out var isH) && isH.GetBoolean())
+        {
+            var rowProps = tableRow.TableRowProperties ?? new TableRowProperties();
+            rowProps.AppendChild(new TableHeader());
+            tableRow.TableRowProperties = rowProps;
+        }
+
+        if (rowJson.TryGetProperty("cells", out var cells) && cells.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var cell in cells.EnumerateArray())
+            {
+                if (cell.ValueKind == JsonValueKind.Object)
+                {
+                    tableRow.AppendChild(CreateRichTableCell(cell, false));
+                }
+                else
+                {
+                    var tc = new TableCell();
+                    var p = new Paragraph();
+                    var r = new Run();
+                    r.AppendChild(new Text(cell.GetString() ?? cell.ToString())
+                        { Space = SpaceProcessingModeValues.Preserve });
+                    p.AppendChild(r);
+                    tc.AppendChild(p);
+                    tableRow.AppendChild(tc);
+                }
+            }
+        }
+
+        return tableRow;
+    }
+
+    /// <summary>
+    /// Create a rich table cell from a JSON object with text, style, runs, etc.
+    /// </summary>
+    public static TableCell CreateRichTableCell(JsonElement cellJson, bool isHeader)
+    {
+        var tc = new TableCell();
+
+        // Cell properties
+        var tcProps = new TableCellProperties();
+        bool hasProps = false;
+
+        if (cellJson.TryGetProperty("width", out var w))
+        {
+            tcProps.TableCellWidth = new TableCellWidth
+            {
+                Width = w.GetInt32().ToString(),
+                Type = TableWidthUnitValues.Dxa
+            };
+            hasProps = true;
+        }
+
+        if (cellJson.TryGetProperty("vertical_align", out var vAlign))
+        {
+            tcProps.TableCellVerticalAlignment = new TableCellVerticalAlignment
+            {
+                Val = vAlign.GetString()?.ToLowerInvariant() switch
+                {
+                    "top" => TableVerticalAlignmentValues.Top,
+                    "center" => TableVerticalAlignmentValues.Center,
+                    "bottom" => TableVerticalAlignmentValues.Bottom,
+                    _ => TableVerticalAlignmentValues.Top
+                }
+            };
+            hasProps = true;
+        }
+
+        if (cellJson.TryGetProperty("shading", out var shading))
+        {
+            tcProps.Shading = new Shading
+            {
+                Fill = shading.GetString(),
+                Val = ShadingPatternValues.Clear
+            };
+            hasProps = true;
+        }
+
+        if (cellJson.TryGetProperty("col_span", out var colSpan))
+        {
+            tcProps.GridSpan = new GridSpan { Val = colSpan.GetInt32() };
+            hasProps = true;
+        }
+
+        if (cellJson.TryGetProperty("row_span", out var rowSpan))
+        {
+            var spanVal = rowSpan.GetString()?.ToLowerInvariant();
+            if (spanVal == "restart")
+                tcProps.VerticalMerge = new VerticalMerge { Val = MergedCellValues.Restart };
+            else if (spanVal == "continue")
+                tcProps.VerticalMerge = new VerticalMerge();
+            hasProps = true;
+        }
+
+        // Cell borders
+        if (cellJson.TryGetProperty("borders", out var borders))
+        {
+            tcProps.TableCellBorders = CreateCellBorders(borders);
+            hasProps = true;
+        }
+
+        if (hasProps)
+            tc.AppendChild(tcProps);
+
+        // Cell content: supports runs array, paragraphs array, or flat text
+        if (cellJson.TryGetProperty("paragraphs", out var paragraphs) && paragraphs.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var pJson in paragraphs.EnumerateArray())
+            {
+                if (pJson.ValueKind == JsonValueKind.Object)
+                {
+                    var pType = pJson.TryGetProperty("type", out var t) ? t.GetString() : "paragraph";
+                    if (pType == "heading")
+                        tc.AppendChild(CreateHeading(pJson));
+                    else
+                        tc.AppendChild(CreateParagraph(pJson));
+                }
+                else
+                {
+                    var p = new Paragraph();
+                    var r = new Run();
+                    r.AppendChild(new Text(pJson.GetString() ?? "") { Space = SpaceProcessingModeValues.Preserve });
+                    p.AppendChild(r);
+                    tc.AppendChild(p);
+                }
+            }
+        }
+        else if (cellJson.TryGetProperty("runs", out var runs) && runs.ValueKind == JsonValueKind.Array)
+        {
+            // Runs in a single paragraph
+            var p = new Paragraph();
+            foreach (var runJson in runs.EnumerateArray())
+            {
+                p.AppendChild(CreateRun(runJson));
+            }
+            tc.AppendChild(p);
+        }
+        else
+        {
+            var p = new Paragraph();
+            var r = new Run();
+            if (isHeader)
+                r.RunProperties = new RunProperties { Bold = new Bold() };
+
+            if (cellJson.TryGetProperty("style", out var cellStyle))
+                r.RunProperties = CreateRunProperties(cellStyle);
+
+            var text = cellJson.TryGetProperty("text", out var txt)
+                ? txt.GetString() ?? ""
+                : "";
+            r.AppendChild(new Text(text) { Space = SpaceProcessingModeValues.Preserve });
+            p.AppendChild(r);
+            tc.AppendChild(p);
+        }
+
+        return tc;
+    }
+
+    /// <summary>
+    /// Create cell border properties from JSON.
+    /// </summary>
+    private static TableCellBorders CreateCellBorders(JsonElement borders)
+    {
+        var cb = new TableCellBorders();
+
+        if (borders.TryGetProperty("top", out var top))
+            cb.TopBorder = new TopBorder { Val = ParseBorderValue(top.GetString()), Size = 4 };
+        if (borders.TryGetProperty("bottom", out var bottom))
+            cb.BottomBorder = new BottomBorder { Val = ParseBorderValue(bottom.GetString()), Size = 4 };
+        if (borders.TryGetProperty("left", out var left))
+            cb.LeftBorder = new LeftBorder { Val = ParseBorderValue(left.GetString()), Size = 4 };
+        if (borders.TryGetProperty("right", out var right))
+            cb.RightBorder = new RightBorder { Val = ParseBorderValue(right.GetString()), Size = 4 };
+
+        return cb;
+    }
+
+    private static BorderValues ParseBorderValue(string? style)
+    {
+        return style?.ToLowerInvariant() switch
+        {
+            "single" => BorderValues.Single,
+            "double" => BorderValues.Double,
+            "dashed" => BorderValues.Dashed,
+            "dotted" => BorderValues.Dotted,
+            "none" or "nil" => BorderValues.Nil,
+            "thick" => BorderValues.Thick,
+            "thin_thick_small_gap" => BorderValues.ThinThickSmallGap,
+            _ => BorderValues.Single
+        };
     }
 
     private static Paragraph CreateImage(JsonElement value, MainDocumentPart mainPart)

--- a/src/DocxMcp/Tools/PatchTool.cs
+++ b/src/DocxMcp/Tools/PatchTool.cs
@@ -19,17 +19,31 @@ public sealed class PatchTool
         "  replace — Replace element or property at path.\n" +
         "  remove — Delete element at path.\n" +
         "  move — Move element from one location to another.\n" +
-        "  copy — Duplicate element to another location.\n\n" +
+        "  copy — Duplicate element to another location.\n" +
+        "  replace_text — Find/replace text preserving run-level formatting.\n" +
+        "  remove_column — Remove a column from a table by index.\n\n" +
         "Value types (for add/replace):\n" +
-        "  {\"type\": \"paragraph\", \"text\": \"...\", \"style\": {\"bold\": true}}\n" +
-        "  {\"type\": \"heading\", \"level\": 2, \"text\": \"...\"}\n" +
-        "  {\"type\": \"table\", \"rows\": [[\"A\",\"B\"]], \"headers\": [\"Col1\",\"Col2\"]}\n" +
-        "  {\"type\": \"image\", \"path\": \"/tmp/img.png\", \"width\": 200, \"height\": 150}\n" +
-        "  {\"type\": \"hyperlink\", \"text\": \"Click\", \"url\": \"https://...\"}\n" +
-        "  {\"type\": \"page_break\"}\n" +
-        "  {\"type\": \"list\", \"items\": [\"a\",\"b\",\"c\"], \"ordered\": false}\n\n" +
+        "  Paragraph with runs (preserves styling):\n" +
+        "    {\"type\": \"paragraph\", \"runs\": [{\"text\": \"bold\", \"style\": {\"bold\": true}}, {\"tab\": true}, {\"text\": \"normal\"}]}\n" +
+        "    {\"type\": \"paragraph\", \"properties\": {\"alignment\": \"center\", \"tabs\": [{\"position\": 4680, \"alignment\": \"center\"}]}, \"runs\": [...]}\n" +
+        "  Paragraph with flat text (legacy):\n" +
+        "    {\"type\": \"paragraph\", \"text\": \"...\", \"style\": {\"bold\": true}}\n" +
+        "  Heading with runs:\n" +
+        "    {\"type\": \"heading\", \"level\": 2, \"runs\": [{\"text\": \"Title \", \"style\": {\"color\": \"2E5496\"}}, {\"tab\": true}, {\"text\": \"Company\"}]}\n" +
+        "  Table:\n" +
+        "    {\"type\": \"table\", \"headers\": [\"Col1\",\"Col2\"], \"rows\": [[\"A\",\"B\"]]}\n" +
+        "    Rich: {\"type\": \"table\", \"headers\": [{\"text\": \"H1\", \"shading\": \"E0E0E0\"}], \"rows\": [{\"cells\": [{\"text\": \"A\", \"style\": {\"bold\": true}}]}]}\n" +
+        "  Row: {\"type\": \"row\", \"cells\": [\"A\", \"B\"], \"is_header\": true, \"height\": 400}\n" +
+        "  Cell: {\"type\": \"cell\", \"text\": \"val\", \"shading\": \"FF0000\", \"col_span\": 2, \"vertical_align\": \"center\"}\n" +
+        "  Other: image, hyperlink, page_break, section_break, list\n\n" +
+        "Run content types:\n" +
+        "  {\"text\": \"hello\", \"style\": {\"bold\": true, \"italic\": true, \"font_size\": 14, \"font_name\": \"Arial\", \"color\": \"FF0000\"}}\n" +
+        "  {\"tab\": true} — tab character\n" +
+        "  {\"break\": \"line\"} — line/page/column break\n\n" +
         "Style properties (for replace on /style paths):\n" +
-        "  {\"bold\": true, \"italic\": false, \"font_size\": 14, \"color\": \"FF0000\"}")]
+        "  {\"bold\": true, \"italic\": false, \"font_size\": 14, \"color\": \"FF0000\"}\n\n" +
+        "replace_text: {\"op\": \"replace_text\", \"path\": \"/body/paragraph[0]\", \"find\": \"old\", \"replace\": \"new\"}\n" +
+        "remove_column: {\"op\": \"remove_column\", \"path\": \"/body/table[0]\", \"column\": 2}")]
     public static string ApplyPatch(
         SessionManager sessions,
         [Description("Session ID of the document.")] string doc_id,
@@ -79,6 +93,12 @@ public sealed class PatchTool
                         break;
                     case "copy":
                         ApplyCopy(patch, wpDoc);
+                        break;
+                    case "replace_text":
+                        ApplyReplaceText(patch, wpDoc);
+                        break;
+                    case "remove_column":
+                        ApplyRemoveColumn(patch, wpDoc);
                         break;
                     default:
                         results.Add($"Unknown operation: '{op}'");
@@ -177,6 +197,11 @@ public sealed class PatchTool
                     var newProps = ElementFactory.CreateRunProperties(value);
                     target.Parent?.ReplaceChild(newProps, target);
                 }
+                else if (target is TableProperties)
+                {
+                    var newProps = ElementFactory.CreateTableProperties(value);
+                    target.Parent?.ReplaceChild(newProps, target);
+                }
             }
             return;
         }
@@ -268,6 +293,165 @@ public sealed class PatchTool
 
             var target = targets[0];
             target.Parent?.InsertAfter(clone, target);
+        }
+    }
+
+    /// <summary>
+    /// Find and replace text within runs, preserving all run-level formatting.
+    /// Works on paragraphs, headings, table cells, or any element containing runs.
+    /// </summary>
+    private static void ApplyReplaceText(JsonElement patch, WordprocessingDocument wpDoc)
+    {
+        var pathStr = patch.GetProperty("path").GetString()
+            ?? throw new ArgumentException("replace_text must have a 'path' field.");
+        var find = patch.GetProperty("find").GetString()
+            ?? throw new ArgumentException("replace_text must have a 'find' field.");
+        var replace = patch.GetProperty("replace").GetString()
+            ?? throw new ArgumentException("replace_text must have a 'replace' field.");
+
+        var path = DocxPath.Parse(pathStr);
+        var targets = PathResolver.Resolve(path, wpDoc);
+
+        if (targets.Count == 0)
+            throw new InvalidOperationException($"No elements found at path '{pathStr}'.");
+
+        foreach (var target in targets)
+        {
+            ReplaceTextInElement(target, find, replace);
+        }
+    }
+
+    /// <summary>
+    /// Replace text within an element's runs, preserving formatting.
+    /// Handles text that spans across multiple runs by performing per-run replacement
+    /// for simple cases, and cross-run replacement for multi-run spans.
+    /// </summary>
+    private static void ReplaceTextInElement(OpenXmlElement element, string find, string replace)
+    {
+        // Collect all paragraphs (direct or nested)
+        var paragraphs = element is Paragraph p
+            ? new List<Paragraph> { p }
+            : element.Descendants<Paragraph>().ToList();
+
+        foreach (var para in paragraphs)
+        {
+            var runs = para.Elements<Run>().ToList();
+            if (runs.Count == 0) continue;
+
+            // Try simple per-run replacement first
+            bool found = false;
+            foreach (var run in runs)
+            {
+                var textElem = run.GetFirstChild<Text>();
+                if (textElem is null) continue;
+
+                var text = textElem.Text;
+                if (text.Contains(find, StringComparison.Ordinal))
+                {
+                    textElem.Text = text.Replace(find, replace, StringComparison.Ordinal);
+                    found = true;
+                }
+            }
+
+            if (found) continue;
+
+            // Cross-run replacement: concatenate all run texts, find the match,
+            // then adjust the runs that contain the match
+            var allText = string.Concat(runs.Select(r => r.InnerText));
+            var matchIdx = allText.IndexOf(find, StringComparison.Ordinal);
+            if (matchIdx < 0) continue;
+
+            // Map character positions to runs
+            int pos = 0;
+            foreach (var run in runs)
+            {
+                var textElem = run.GetFirstChild<Text>();
+                if (textElem is null)
+                {
+                    // Tab or break: count as 1 char (\t or empty)
+                    var runText = run.InnerText;
+                    pos += runText.Length;
+                    continue;
+                }
+
+                var runStart = pos;
+                var runEnd = pos + textElem.Text.Length;
+
+                // Check if this run overlaps with the find range
+                var findEnd = matchIdx + find.Length;
+
+                if (runEnd <= matchIdx || runStart >= findEnd)
+                {
+                    // No overlap
+                    pos = runEnd;
+                    continue;
+                }
+
+                // This run overlaps with the search text
+                var overlapStart = Math.Max(matchIdx, runStart) - runStart;
+                var overlapEnd = Math.Min(findEnd, runEnd) - runStart;
+
+                var before = textElem.Text[..overlapStart];
+                var after = textElem.Text[overlapEnd..];
+
+                // First overlapping run gets the replacement text
+                if (runStart <= matchIdx)
+                {
+                    textElem.Text = before + replace + after;
+                    textElem.Space = SpaceProcessingModeValues.Preserve;
+                }
+                else
+                {
+                    // Subsequent overlapping runs: remove the overlapping portion
+                    textElem.Text = after;
+                    textElem.Space = SpaceProcessingModeValues.Preserve;
+                }
+
+                pos = runEnd;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Remove a column from a table by index (0-based).
+    /// Removes the cell at the given column index from every row.
+    /// </summary>
+    private static void ApplyRemoveColumn(JsonElement patch, WordprocessingDocument wpDoc)
+    {
+        var pathStr = patch.GetProperty("path").GetString()
+            ?? throw new ArgumentException("remove_column must have a 'path' field.");
+        var column = patch.GetProperty("column").GetInt32();
+
+        var path = DocxPath.Parse(pathStr);
+        var targets = PathResolver.Resolve(path, wpDoc);
+
+        if (targets.Count == 0)
+            throw new InvalidOperationException($"No elements found at path '{pathStr}'.");
+
+        foreach (var target in targets)
+        {
+            if (target is not Table table)
+                throw new InvalidOperationException("remove_column target must be a table.");
+
+            foreach (var row in table.Elements<TableRow>())
+            {
+                var cells = row.Elements<TableCell>().ToList();
+                if (column >= 0 && column < cells.Count)
+                {
+                    row.RemoveChild(cells[column]);
+                }
+            }
+
+            // Update grid columns if present
+            var grid = table.GetFirstChild<TableGrid>();
+            if (grid is not null)
+            {
+                var gridCols = grid.Elements<GridColumn>().ToList();
+                if (column >= 0 && column < gridCols.Count)
+                {
+                    grid.RemoveChild(gridCols[column]);
+                }
+            }
         }
     }
 }

--- a/tests/DocxMcp.Tests/QueryRoundTripTests.cs
+++ b/tests/DocxMcp.Tests/QueryRoundTripTests.cs
@@ -1,0 +1,266 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using DocxMcp.Helpers;
+using DocxMcp.Tools;
+using System.Text.Json;
+using Xunit;
+
+namespace DocxMcp.Tests;
+
+/// <summary>
+/// Tests that queried JSON output can be fed back into patch operations
+/// (round-trip fidelity), including tabs, runs, and paragraph properties.
+/// </summary>
+public class QueryRoundTripTests : IDisposable
+{
+    private readonly DocxSession _session;
+    private readonly SessionManager _sessions;
+
+    public QueryRoundTripTests()
+    {
+        _sessions = new SessionManager();
+        _session = _sessions.Create();
+    }
+
+    [Fact]
+    public void QuerySingleRunIncludesRunsArray()
+    {
+        var body = _session.GetBody();
+        body.AppendChild(new Paragraph(new Run(new Text("Single run"))));
+
+        var result = QueryTool.Query(_sessions, _session.Id, "/body/paragraph[0]");
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+
+        // Runs array should always be present, even for single run
+        Assert.True(root.TryGetProperty("runs", out var runs));
+        Assert.Equal(1, runs.GetArrayLength());
+        Assert.Equal("Single run", runs[0].GetProperty("text").GetString());
+    }
+
+    [Fact]
+    public void QueryTabRunDetectedCorrectly()
+    {
+        var body = _session.GetBody();
+        var p = new Paragraph(
+            new Run(new Text("Before") { Space = SpaceProcessingModeValues.Preserve }),
+            new Run(new TabChar()),
+            new Run(new Text("After") { Space = SpaceProcessingModeValues.Preserve }));
+        body.AppendChild(p);
+
+        var result = QueryTool.Query(_sessions, _session.Id, "/body/paragraph[0]");
+        using var doc = JsonDocument.Parse(result);
+        var runs = doc.RootElement.GetProperty("runs");
+
+        Assert.Equal(3, runs.GetArrayLength());
+
+        Assert.Equal("Before", runs[0].GetProperty("text").GetString());
+
+        // Tab run
+        Assert.True(runs[1].GetProperty("tab").GetBoolean());
+        Assert.Equal("\t", runs[1].GetProperty("text").GetString());
+
+        Assert.Equal("After", runs[2].GetProperty("text").GetString());
+    }
+
+    [Fact]
+    public void QueryBreakRunDetectedCorrectly()
+    {
+        var body = _session.GetBody();
+        var p = new Paragraph(
+            new Run(new Text("Before")),
+            new Run(new Break { Type = BreakValues.Page }),
+            new Run(new Text("After")));
+        body.AppendChild(p);
+
+        var result = QueryTool.Query(_sessions, _session.Id, "/body/paragraph[0]");
+        using var doc = JsonDocument.Parse(result);
+        var runs = doc.RootElement.GetProperty("runs");
+
+        Assert.Equal(3, runs.GetArrayLength());
+        Assert.Equal("page", runs[1].GetProperty("break").GetString());
+    }
+
+    [Fact]
+    public void QueryParagraphPropertiesIncluded()
+    {
+        var body = _session.GetBody();
+        var p = new Paragraph(
+            new ParagraphProperties(
+                new Justification { Val = JustificationValues.Center },
+                new SpacingBetweenLines { Before = "120", After = "240", Line = "360" },
+                new Indentation { Left = "720", Right = "360" }),
+            new Run(new Text("Formatted")));
+        body.AppendChild(p);
+
+        var result = QueryTool.Query(_sessions, _session.Id, "/body/paragraph[0]");
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+
+        Assert.True(root.TryGetProperty("properties", out var props));
+        Assert.Equal("center", props.GetProperty("alignment").GetString());
+        Assert.Equal(120, props.GetProperty("spacing_before").GetInt32());
+        Assert.Equal(240, props.GetProperty("spacing_after").GetInt32());
+        Assert.Equal(360, props.GetProperty("line_spacing").GetInt32());
+        Assert.Equal(720, props.GetProperty("indent_left").GetInt32());
+        Assert.Equal(360, props.GetProperty("indent_right").GetInt32());
+    }
+
+    [Fact]
+    public void QueryTabStopsIncluded()
+    {
+        var body = _session.GetBody();
+        var p = new Paragraph(
+            new ParagraphProperties(
+                new Tabs(
+                    new TabStop { Val = TabStopValues.Center, Position = 4680 },
+                    new TabStop { Val = TabStopValues.Right, Position = 9360, Leader = TabStopLeaderCharValues.Dot })),
+            new Run(new Text("Left")),
+            new Run(new TabChar()),
+            new Run(new Text("Center")),
+            new Run(new TabChar()),
+            new Run(new Text("Right")));
+        body.AppendChild(p);
+
+        var result = QueryTool.Query(_sessions, _session.Id, "/body/paragraph[0]");
+        using var doc = JsonDocument.Parse(result);
+        var props = doc.RootElement.GetProperty("properties");
+        var tabs = props.GetProperty("tabs");
+
+        Assert.Equal(2, tabs.GetArrayLength());
+
+        Assert.Equal(4680, tabs[0].GetProperty("position").GetInt32());
+        Assert.Equal("center", tabs[0].GetProperty("alignment").GetString());
+
+        Assert.Equal(9360, tabs[1].GetProperty("position").GetInt32());
+        Assert.Equal("right", tabs[1].GetProperty("alignment").GetString());
+        Assert.Equal("dot", tabs[1].GetProperty("leader").GetString());
+    }
+
+    [Fact]
+    public void QueryRunStylesPreserved()
+    {
+        var body = _session.GetBody();
+        var p = new Paragraph(
+            new Run(
+                new RunProperties(
+                    new Bold(),
+                    new Italic(),
+                    new FontSize { Val = "24" },
+                    new RunFonts { Ascii = "Arial" },
+                    new Color { Val = "FF0000" }),
+                new Text("Styled run")));
+        body.AppendChild(p);
+
+        var result = QueryTool.Query(_sessions, _session.Id, "/body/paragraph[0]");
+        using var doc = JsonDocument.Parse(result);
+        var runStyle = doc.RootElement.GetProperty("runs")[0].GetProperty("style");
+
+        Assert.True(runStyle.GetProperty("bold").GetBoolean());
+        Assert.True(runStyle.GetProperty("italic").GetBoolean());
+        Assert.Equal(12, runStyle.GetProperty("font_size").GetInt32()); // 24 half-points = 12pt
+        Assert.Equal("Arial", runStyle.GetProperty("font_name").GetString());
+        Assert.Equal("FF0000", runStyle.GetProperty("color").GetString());
+    }
+
+    [Fact]
+    public void RoundTripCreateThenQueryParagraph()
+    {
+        // Create a paragraph with runs via patch
+        var patchResult = PatchTool.ApplyPatch(_sessions, _session.Id, """
+        [{
+            "op": "add",
+            "path": "/body/children/0",
+            "value": {
+                "type": "paragraph",
+                "properties": {
+                    "alignment": "right",
+                    "spacing_after": 100
+                },
+                "runs": [
+                    {"text": "Title ", "style": {"bold": true, "font_size": 14, "color": "0000FF"}},
+                    {"tab": true},
+                    {"text": "Subtitle", "style": {"italic": true}}
+                ]
+            }
+        }]
+        """);
+
+        Assert.Contains("Applied 1 patch(es) successfully", patchResult);
+
+        // Query it back
+        var queryResult = QueryTool.Query(_sessions, _session.Id, "/body/paragraph[0]");
+        using var doc = JsonDocument.Parse(queryResult);
+        var root = doc.RootElement;
+
+        // Verify paragraph properties
+        Assert.Equal("right", root.GetProperty("properties").GetProperty("alignment").GetString());
+        Assert.Equal(100, root.GetProperty("properties").GetProperty("spacing_after").GetInt32());
+
+        // Verify runs
+        var runs = root.GetProperty("runs");
+        Assert.Equal(3, runs.GetArrayLength());
+
+        // First run
+        Assert.Equal("Title ", runs[0].GetProperty("text").GetString());
+        var firstStyle = runs[0].GetProperty("style");
+        Assert.True(firstStyle.GetProperty("bold").GetBoolean());
+        Assert.Equal(14, firstStyle.GetProperty("font_size").GetInt32());
+        Assert.Equal("0000FF", firstStyle.GetProperty("color").GetString());
+
+        // Tab run
+        Assert.True(runs[1].GetProperty("tab").GetBoolean());
+
+        // Third run
+        Assert.Equal("Subtitle", runs[2].GetProperty("text").GetString());
+        Assert.True(runs[2].GetProperty("style").GetProperty("italic").GetBoolean());
+    }
+
+    [Fact]
+    public void RoundTripCreateThenQueryHeading()
+    {
+        var patchResult = PatchTool.ApplyPatch(_sessions, _session.Id, """
+        [{
+            "op": "add",
+            "path": "/body/children/0",
+            "value": {
+                "type": "heading",
+                "level": 2,
+                "runs": [
+                    {"text": "Senior Engineer  ", "style": {"color": "2E5496"}},
+                    {"tab": true, "style": {"color": "2E5496"}},
+                    {"text": "ACME Corp", "style": {"bold": true}},
+                    {"tab": true, "style": {"bold": true}},
+                    {"text": "2020-2023", "style": {"italic": true}}
+                ]
+            }
+        }]
+        """);
+
+        Assert.Contains("Applied 1 patch(es) successfully", patchResult);
+
+        var queryResult = QueryTool.Query(_sessions, _session.Id, "/body/heading[0]");
+        using var doc = JsonDocument.Parse(queryResult);
+        var heading = doc.RootElement; // Single heading
+
+        Assert.Equal("heading", heading.GetProperty("type").GetString());
+        Assert.Equal(2, heading.GetProperty("level").GetInt32());
+        Assert.Equal("Heading2", heading.GetProperty("style").GetString());
+
+        var runs = heading.GetProperty("runs");
+        Assert.Equal(5, runs.GetArrayLength());
+
+        // Verify tab runs
+        Assert.True(runs[1].GetProperty("tab").GetBoolean());
+        Assert.Equal("2E5496", runs[1].GetProperty("style").GetProperty("color").GetString());
+
+        Assert.True(runs[3].GetProperty("tab").GetBoolean());
+        Assert.True(runs[3].GetProperty("style").GetProperty("bold").GetBoolean());
+    }
+
+    public void Dispose()
+    {
+        _sessions.Close(_session.Id);
+    }
+}

--- a/tests/DocxMcp.Tests/RunLevelWriteTests.cs
+++ b/tests/DocxMcp.Tests/RunLevelWriteTests.cs
@@ -1,0 +1,548 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using DocxMcp.Helpers;
+using DocxMcp.Paths;
+using System.Text.Json;
+using Xunit;
+
+namespace DocxMcp.Tests;
+
+public class RunLevelWriteTests : IDisposable
+{
+    private readonly DocxSession _session;
+
+    public RunLevelWriteTests()
+    {
+        _session = DocxSession.Create();
+    }
+
+    [Fact]
+    public void CreateParagraphWithRunsArray()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "paragraph",
+            "runs": [
+                {"text": "Hello ", "style": {"bold": true}},
+                {"text": "World"}
+            ]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var p = Assert.IsType<Paragraph>(element);
+        var runs = p.Elements<Run>().ToList();
+
+        Assert.Equal(2, runs.Count);
+        Assert.Equal("Hello ", runs[0].InnerText);
+        Assert.NotNull(runs[0].RunProperties?.Bold);
+        Assert.Equal("World", runs[1].InnerText);
+        Assert.Null(runs[1].RunProperties);
+    }
+
+    [Fact]
+    public void CreateParagraphWithTabRun()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "paragraph",
+            "runs": [
+                {"text": "Title"},
+                {"tab": true},
+                {"text": "Company"}
+            ]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var p = Assert.IsType<Paragraph>(element);
+        var runs = p.Elements<Run>().ToList();
+
+        Assert.Equal(3, runs.Count);
+        Assert.Equal("Title", runs[0].InnerText);
+        Assert.NotNull(runs[1].GetFirstChild<TabChar>());
+        Assert.Equal("Company", runs[2].InnerText);
+    }
+
+    [Fact]
+    public void CreateParagraphWithBreakRun()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "paragraph",
+            "runs": [
+                {"text": "Before"},
+                {"break": "line"},
+                {"text": "After"}
+            ]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var p = Assert.IsType<Paragraph>(element);
+        var runs = p.Elements<Run>().ToList();
+
+        Assert.Equal(3, runs.Count);
+        var brk = runs[1].GetFirstChild<Break>();
+        Assert.NotNull(brk);
+        Assert.Equal(BreakValues.TextWrapping, brk!.Type?.Value);
+    }
+
+    [Fact]
+    public void CreateParagraphWithPageBreakRun()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "paragraph",
+            "runs": [
+                {"break": "page"}
+            ]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var p = Assert.IsType<Paragraph>(element);
+        var runs = p.Elements<Run>().ToList();
+
+        Assert.Single(runs);
+        var brk = runs[0].GetFirstChild<Break>();
+        Assert.NotNull(brk);
+        Assert.Equal(BreakValues.Page, brk!.Type?.Value);
+    }
+
+    [Fact]
+    public void CreateParagraphWithFullRunStyling()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "paragraph",
+            "runs": [
+                {
+                    "text": "Styled",
+                    "style": {
+                        "bold": true,
+                        "italic": true,
+                        "underline": true,
+                        "strike": true,
+                        "font_size": 16,
+                        "font_name": "Arial",
+                        "color": "FF0000"
+                    }
+                }
+            ]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var p = Assert.IsType<Paragraph>(element);
+        var run = p.Elements<Run>().Single();
+        var rp = run.RunProperties;
+
+        Assert.NotNull(rp);
+        Assert.NotNull(rp!.Bold);
+        Assert.NotNull(rp.Italic);
+        Assert.NotNull(rp.Underline);
+        Assert.NotNull(rp.Strike);
+        Assert.Equal("32", rp.FontSize?.Val?.Value); // 16pt = 32 half-points
+        Assert.Equal("Arial", rp.RunFonts?.Ascii?.Value);
+        Assert.Equal("FF0000", rp.Color?.Val?.Value);
+    }
+
+    [Fact]
+    public void CreateParagraphWithHighlightAndVerticalAlign()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "paragraph",
+            "runs": [
+                {"text": "Normal"},
+                {"text": "2", "style": {"vertical_align": "superscript"}},
+                {"text": " highlighted", "style": {"highlight": "yellow"}}
+            ]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var p = Assert.IsType<Paragraph>(element);
+        var runs = p.Elements<Run>().ToList();
+
+        Assert.Equal(3, runs.Count);
+        Assert.Equal(VerticalPositionValues.Superscript,
+            runs[1].RunProperties?.VerticalTextAlignment?.Val?.Value);
+        Assert.Equal(HighlightColorValues.Yellow,
+            runs[2].RunProperties?.Highlight?.Val?.Value);
+    }
+
+    [Fact]
+    public void CreateHeadingWithRunsArray()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "heading",
+            "level": 2,
+            "runs": [
+                {"text": "Job Title  ", "style": {"color": "2E5496"}},
+                {"tab": true},
+                {"text": "Company", "style": {"bold": true}},
+                {"tab": true},
+                {"text": "Jan 2020", "style": {"italic": true}}
+            ]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var p = Assert.IsType<Paragraph>(element);
+
+        // Verify it's a heading
+        Assert.Equal("Heading2", p.ParagraphProperties?.ParagraphStyleId?.Val?.Value);
+
+        // Verify runs
+        var runs = p.Elements<Run>().ToList();
+        Assert.Equal(5, runs.Count);
+
+        Assert.Equal("Job Title  ", runs[0].InnerText);
+        Assert.Equal("2E5496", runs[0].RunProperties?.Color?.Val?.Value);
+
+        Assert.NotNull(runs[1].GetFirstChild<TabChar>());
+
+        Assert.Equal("Company", runs[2].InnerText);
+        Assert.NotNull(runs[2].RunProperties?.Bold);
+
+        Assert.NotNull(runs[3].GetFirstChild<TabChar>());
+
+        Assert.Equal("Jan 2020", runs[4].InnerText);
+        Assert.NotNull(runs[4].RunProperties?.Italic);
+    }
+
+    [Fact]
+    public void CreateHeadingWithFlatTextFallback()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "heading",
+            "level": 1,
+            "text": "Simple Title"
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var p = Assert.IsType<Paragraph>(element);
+        Assert.Equal("Heading1", p.ParagraphProperties?.ParagraphStyleId?.Val?.Value);
+        Assert.Equal("Simple Title", p.InnerText);
+    }
+
+    [Fact]
+    public void CreateParagraphWithProperties()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "paragraph",
+            "properties": {
+                "alignment": "center",
+                "spacing_before": 120,
+                "spacing_after": 240
+            },
+            "runs": [
+                {"text": "Centered paragraph"}
+            ]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var p = Assert.IsType<Paragraph>(element);
+        var pp = p.ParagraphProperties;
+
+        Assert.NotNull(pp);
+        Assert.Equal(JustificationValues.Center, pp!.Justification?.Val?.Value);
+        Assert.Equal("120", pp.SpacingBetweenLines?.Before?.Value);
+        Assert.Equal("240", pp.SpacingBetweenLines?.After?.Value);
+        Assert.Equal("Centered paragraph", p.InnerText);
+    }
+
+    [Fact]
+    public void CreateParagraphWithIndentation()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "paragraph",
+            "properties": {
+                "indent_left": 720,
+                "indent_right": 360,
+                "indent_first_line": 360
+            },
+            "runs": [
+                {"text": "Indented paragraph"}
+            ]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var p = Assert.IsType<Paragraph>(element);
+        var indent = p.ParagraphProperties?.Indentation;
+
+        Assert.NotNull(indent);
+        Assert.Equal("720", indent!.Left?.Value);
+        Assert.Equal("360", indent.Right?.Value);
+        Assert.Equal("360", indent.FirstLine?.Value);
+    }
+
+    [Fact]
+    public void CreateParagraphWithTabStops()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "paragraph",
+            "properties": {
+                "tabs": [
+                    {"position": 4680, "alignment": "center"},
+                    {"position": 9360, "alignment": "right", "leader": "dot"}
+                ]
+            },
+            "runs": [
+                {"text": "Left"},
+                {"tab": true},
+                {"text": "Center"},
+                {"tab": true},
+                {"text": "Right"}
+            ]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var p = Assert.IsType<Paragraph>(element);
+        var tabs = p.ParagraphProperties?.Tabs?.Elements<TabStop>().ToList();
+
+        Assert.NotNull(tabs);
+        Assert.Equal(2, tabs!.Count);
+        Assert.Equal(4680, tabs[0].Position?.Value);
+        Assert.Equal(TabStopValues.Center, tabs[0].Val?.Value);
+        Assert.Equal(9360, tabs[1].Position?.Value);
+        Assert.Equal(TabStopValues.Right, tabs[1].Val?.Value);
+        Assert.Equal(TabStopLeaderCharValues.Dot, tabs[1].Leader?.Value);
+    }
+
+    [Fact]
+    public void CreateHeadingWithPropertiesMerge()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "heading",
+            "level": 2,
+            "properties": {
+                "alignment": "right",
+                "tabs": [
+                    {"position": 9360, "alignment": "right"}
+                ]
+            },
+            "runs": [
+                {"text": "Title"},
+                {"tab": true},
+                {"text": "Date"}
+            ]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var p = Assert.IsType<Paragraph>(element);
+        var pp = p.ParagraphProperties;
+
+        Assert.NotNull(pp);
+        // Heading style is preserved
+        Assert.Equal("Heading2", pp!.ParagraphStyleId?.Val?.Value);
+        // Additional properties are merged
+        Assert.Equal(JustificationValues.Right, pp.Justification?.Val?.Value);
+        Assert.NotNull(pp.Tabs);
+        Assert.Single(pp.Tabs!.Elements<TabStop>());
+    }
+
+    [Fact]
+    public void LegacyFlatTextStillWorks()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "paragraph",
+            "text": "Simple text",
+            "style": {"bold": true}
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var p = Assert.IsType<Paragraph>(element);
+        Assert.Equal("Simple text", p.InnerText);
+
+        var run = p.Elements<Run>().Single();
+        Assert.NotNull(run.RunProperties?.Bold);
+    }
+
+    [Fact]
+    public void CreateRunDirectly()
+    {
+        var runJson = JsonDocument.Parse("""
+            {"text": "Hello", "style": {"bold": true, "color": "FF0000"}}
+        """).RootElement;
+
+        var run = ElementFactory.CreateRun(runJson);
+        Assert.Equal("Hello", run.InnerText);
+        Assert.NotNull(run.RunProperties?.Bold);
+        Assert.Equal("FF0000", run.RunProperties?.Color?.Val?.Value);
+    }
+
+    [Fact]
+    public void CreateTabRunDirectly()
+    {
+        var runJson = JsonDocument.Parse("""{"tab": true}""").RootElement;
+
+        var run = ElementFactory.CreateRun(runJson);
+        Assert.NotNull(run.GetFirstChild<TabChar>());
+    }
+
+    [Fact]
+    public void CreateTabRunWithStyling()
+    {
+        var runJson = JsonDocument.Parse("""
+            {"tab": true, "style": {"font_size": 11}}
+        """).RootElement;
+
+        var run = ElementFactory.CreateRun(runJson);
+        Assert.NotNull(run.GetFirstChild<TabChar>());
+        Assert.Equal("22", run.RunProperties?.FontSize?.Val?.Value);
+    }
+
+    [Fact]
+    public void RoundTripParagraphWithMultipleStyledRuns()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+
+        // Create a paragraph with runs matching the CV heading format
+        var value = JsonDocument.Parse("""
+        {
+            "type": "heading",
+            "level": 2,
+            "runs": [
+                {"text": "Lead Scala Developer  ", "style": {"color": "2E5496"}},
+                {"tab": true, "style": {"color": "2E5496"}},
+                {"text": "_", "style": {"bold": true}},
+                {"text": "Powerspace"},
+                {"text": "_ ", "style": {"bold": true}},
+                {"text": "_", "style": {"bold": true}},
+                {"text": "August 2015 to March 2019"},
+                {"text": " ", "style": {"bold": true, "italic": true, "font_size": 11}}
+            ]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var p = Assert.IsType<Paragraph>(element);
+
+        Assert.Equal("Heading2", p.ParagraphProperties?.ParagraphStyleId?.Val?.Value);
+
+        var runs = p.Elements<Run>().ToList();
+        Assert.Equal(8, runs.Count);
+
+        // First run: colored text
+        Assert.Equal("Lead Scala Developer  ", runs[0].InnerText);
+        Assert.Equal("2E5496", runs[0].RunProperties?.Color?.Val?.Value);
+
+        // Second run: tab
+        Assert.NotNull(runs[1].GetFirstChild<TabChar>());
+        Assert.Equal("2E5496", runs[1].RunProperties?.Color?.Val?.Value);
+
+        // Third run: bold underscore
+        Assert.Equal("_", runs[2].InnerText);
+        Assert.NotNull(runs[2].RunProperties?.Bold);
+
+        // Fourth run: plain text
+        Assert.Equal("Powerspace", runs[3].InnerText);
+        Assert.Null(runs[3].RunProperties);
+
+        // Last run: bold + italic + sized
+        Assert.NotNull(runs[7].RunProperties?.Bold);
+        Assert.NotNull(runs[7].RunProperties?.Italic);
+        Assert.Equal("22", runs[7].RunProperties?.FontSize?.Val?.Value);
+    }
+
+    [Fact]
+    public void ParagraphWithEmptyRunsArrayCreatesNoParagraphContent()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "paragraph",
+            "runs": []
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var p = Assert.IsType<Paragraph>(element);
+        Assert.Empty(p.Elements<Run>());
+    }
+
+    [Fact]
+    public void ParagraphPropertiesWithLineSpacing()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "paragraph",
+            "properties": {
+                "line_spacing": 360,
+                "spacing_before": 0,
+                "spacing_after": 0
+            },
+            "text": "Double-spaced"
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var p = Assert.IsType<Paragraph>(element);
+        var spacing = p.ParagraphProperties?.SpacingBetweenLines;
+
+        Assert.NotNull(spacing);
+        Assert.Equal("360", spacing!.Line?.Value);
+        Assert.Equal("0", spacing.Before?.Value);
+        Assert.Equal("0", spacing.After?.Value);
+    }
+
+    [Fact]
+    public void ParagraphPropertiesWithHangingIndent()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "paragraph",
+            "properties": {
+                "indent_left": 720,
+                "indent_hanging": 360
+            },
+            "text": "Hanging indent paragraph"
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var p = Assert.IsType<Paragraph>(element);
+        var indent = p.ParagraphProperties?.Indentation;
+
+        Assert.NotNull(indent);
+        Assert.Equal("720", indent!.Left?.Value);
+        Assert.Equal("360", indent.Hanging?.Value);
+    }
+
+    public void Dispose()
+    {
+        _session.Dispose();
+    }
+}

--- a/tests/DocxMcp.Tests/TableModificationTests.cs
+++ b/tests/DocxMcp.Tests/TableModificationTests.cs
@@ -1,0 +1,834 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using DocxMcp.Helpers;
+using DocxMcp.Paths;
+using DocxMcp.Tools;
+using System.Text.Json;
+using Xunit;
+
+namespace DocxMcp.Tests;
+
+public class TableModificationTests : IDisposable
+{
+    private readonly DocxSession _session;
+    private readonly SessionManager _sessions;
+
+    public TableModificationTests()
+    {
+        _sessions = new SessionManager();
+        _session = _sessions.Create();
+
+        var body = _session.GetBody();
+
+        // Add a heading
+        body.AppendChild(new Paragraph(
+            new ParagraphProperties(new ParagraphStyleId { Val = "Heading1" }),
+            new Run(new Text("Document"))));
+
+        // Add a table with header row and 2 data rows
+        var table = new Table(
+            new TableProperties(
+                new TableBorders(
+                    new TopBorder { Val = BorderValues.Single, Size = 4 },
+                    new BottomBorder { Val = BorderValues.Single, Size = 4 },
+                    new LeftBorder { Val = BorderValues.Single, Size = 4 },
+                    new RightBorder { Val = BorderValues.Single, Size = 4 },
+                    new InsideHorizontalBorder { Val = BorderValues.Single, Size = 4 },
+                    new InsideVerticalBorder { Val = BorderValues.Single, Size = 4 })));
+
+        // Header row
+        var headerRow = new TableRow(
+            new TableRowProperties(new TableHeader()),
+            new TableCell(new Paragraph(new Run(
+                new RunProperties(new Bold()),
+                new Text("Name")))),
+            new TableCell(new Paragraph(new Run(
+                new RunProperties(new Bold()),
+                new Text("Age")))),
+            new TableCell(new Paragraph(new Run(
+                new RunProperties(new Bold()),
+                new Text("City")))));
+        table.AppendChild(headerRow);
+
+        // Data rows
+        table.AppendChild(new TableRow(
+            new TableCell(new Paragraph(new Run(new Text("Alice")))),
+            new TableCell(new Paragraph(new Run(new Text("30")))),
+            new TableCell(new Paragraph(new Run(new Text("Paris"))))));
+
+        table.AppendChild(new TableRow(
+            new TableCell(new Paragraph(new Run(new Text("Bob")))),
+            new TableCell(new Paragraph(new Run(new Text("25")))),
+            new TableCell(new Paragraph(new Run(new Text("London"))))));
+
+        body.AppendChild(table);
+    }
+
+    // ===========================
+    // Table Creation Tests
+    // ===========================
+
+    [Fact]
+    public void CreateTableWithRichHeaderCells()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "table",
+            "headers": [
+                {"text": "Product", "shading": "E0E0E0", "style": {"bold": true}},
+                {"text": "Price", "shading": "E0E0E0", "style": {"bold": true, "color": "FF0000"}}
+            ],
+            "rows": [["Widget", "$10"], ["Gadget", "$20"]]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var table = Assert.IsType<Table>(element);
+        var rows = table.Elements<TableRow>().ToList();
+
+        Assert.Equal(3, rows.Count); // header + 2 data
+
+        // Check header cell shading
+        var headerCells = rows[0].Elements<TableCell>().ToList();
+        Assert.Equal("Product", headerCells[0].InnerText);
+        Assert.Equal("E0E0E0", headerCells[0].TableCellProperties?.Shading?.Fill?.Value);
+
+        Assert.Equal("Price", headerCells[1].InnerText);
+        Assert.Equal("FF0000",
+            headerCells[1].Descendants<Run>().First().RunProperties?.Color?.Val?.Value);
+    }
+
+    [Fact]
+    public void CreateTableWithRichRowObjects()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "table",
+            "headers": ["Name", "Value"],
+            "rows": [
+                {
+                    "cells": [
+                        {"text": "Total", "style": {"bold": true}},
+                        {"text": "$100", "shading": "FFFF00"}
+                    ]
+                }
+            ]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var table = Assert.IsType<Table>(element);
+        var rows = table.Elements<TableRow>().ToList();
+
+        Assert.Equal(2, rows.Count); // header + 1 data
+        var dataCells = rows[1].Elements<TableCell>().ToList();
+
+        Assert.Equal("Total", dataCells[0].InnerText);
+        Assert.NotNull(dataCells[0].Descendants<Run>().First().RunProperties?.Bold);
+
+        Assert.Equal("$100", dataCells[1].InnerText);
+        Assert.Equal("FFFF00", dataCells[1].TableCellProperties?.Shading?.Fill?.Value);
+    }
+
+    [Fact]
+    public void CreateTableWithCellSpanning()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "table",
+            "rows": [
+                {
+                    "cells": [
+                        {"text": "Merged Header", "col_span": 3, "style": {"bold": true}}
+                    ]
+                },
+                {
+                    "cells": [
+                        {"text": "A"},
+                        {"text": "B"},
+                        {"text": "C"}
+                    ]
+                }
+            ]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var table = Assert.IsType<Table>(element);
+        var rows = table.Elements<TableRow>().ToList();
+
+        Assert.Equal(2, rows.Count);
+        var mergedCell = rows[0].Elements<TableCell>().First();
+        Assert.Equal(3, mergedCell.TableCellProperties?.GridSpan?.Val?.Value);
+    }
+
+    [Fact]
+    public void CreateTableWithVerticalMerge()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "table",
+            "rows": [
+                {
+                    "cells": [
+                        {"text": "Span Start", "row_span": "restart"},
+                        {"text": "Row 1"}
+                    ]
+                },
+                {
+                    "cells": [
+                        {"text": "", "row_span": "continue"},
+                        {"text": "Row 2"}
+                    ]
+                }
+            ]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var table = Assert.IsType<Table>(element);
+        var rows = table.Elements<TableRow>().ToList();
+
+        var firstCell = rows[0].Elements<TableCell>().First();
+        Assert.Equal(MergedCellValues.Restart,
+            firstCell.TableCellProperties?.VerticalMerge?.Val?.Value);
+
+        var secondCell = rows[1].Elements<TableCell>().First();
+        Assert.NotNull(secondCell.TableCellProperties?.VerticalMerge);
+        // Continue has no Val attribute
+        Assert.Null(secondCell.TableCellProperties?.VerticalMerge?.Val);
+    }
+
+    [Fact]
+    public void CreateTableWithCellVerticalAlignment()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "table",
+            "rows": [
+                {
+                    "cells": [
+                        {"text": "Top", "vertical_align": "top"},
+                        {"text": "Center", "vertical_align": "center"},
+                        {"text": "Bottom", "vertical_align": "bottom"}
+                    ]
+                }
+            ]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var table = Assert.IsType<Table>(element);
+        var cells = table.Descendants<TableCell>().ToList();
+
+        Assert.Equal(TableVerticalAlignmentValues.Top,
+            cells[0].TableCellProperties?.TableCellVerticalAlignment?.Val?.Value);
+        Assert.Equal(TableVerticalAlignmentValues.Center,
+            cells[1].TableCellProperties?.TableCellVerticalAlignment?.Val?.Value);
+        Assert.Equal(TableVerticalAlignmentValues.Bottom,
+            cells[2].TableCellProperties?.TableCellVerticalAlignment?.Val?.Value);
+    }
+
+    [Fact]
+    public void CreateTableWithBorderStyle()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "table",
+            "border_style": "double",
+            "border_size": 8,
+            "rows": [["A"]]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var table = Assert.IsType<Table>(element);
+        var borders = table.GetFirstChild<TableProperties>()?.TableBorders;
+
+        Assert.NotNull(borders);
+        Assert.Equal(BorderValues.Double, borders!.TopBorder?.Val?.Value);
+        Assert.Equal(8u, borders.TopBorder?.Size?.Value);
+    }
+
+    [Fact]
+    public void CreateTableWithNoBorders()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "table",
+            "border_style": "none",
+            "rows": [["A"]]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var table = Assert.IsType<Table>(element);
+        var borders = table.GetFirstChild<TableProperties>()?.TableBorders;
+
+        Assert.Null(borders);
+    }
+
+    [Fact]
+    public void CreateTableWithWidthAndAlignment()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "table",
+            "width": 5000,
+            "width_type": "pct",
+            "table_alignment": "center",
+            "rows": [["A"]]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var table = Assert.IsType<Table>(element);
+        var tblProps = table.GetFirstChild<TableProperties>();
+
+        Assert.Equal("5000", tblProps?.TableWidth?.Width?.Value);
+        Assert.Equal(TableWidthUnitValues.Pct, tblProps?.TableWidth?.Type?.Value);
+        Assert.Equal(TableRowAlignmentValues.Center, tblProps?.TableJustification?.Val?.Value);
+    }
+
+    [Fact]
+    public void CreateTableWithCellBorders()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "table",
+            "rows": [
+                {
+                    "cells": [
+                        {
+                            "text": "Custom borders",
+                            "borders": {
+                                "top": "double",
+                                "bottom": "single",
+                                "left": "dotted",
+                                "right": "dashed"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var table = Assert.IsType<Table>(element);
+        var cell = table.Descendants<TableCell>().First();
+        var cb = cell.TableCellProperties?.TableCellBorders;
+
+        Assert.NotNull(cb);
+        Assert.Equal(BorderValues.Double, cb!.TopBorder?.Val?.Value);
+        Assert.Equal(BorderValues.Single, cb.BottomBorder?.Val?.Value);
+        Assert.Equal(BorderValues.Dotted, cb.LeftBorder?.Val?.Value);
+        Assert.Equal(BorderValues.Dashed, cb.RightBorder?.Val?.Value);
+    }
+
+    [Fact]
+    public void CreateRowAsTopLevelType()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "row",
+            "is_header": true,
+            "cells": [
+                {"text": "Col1", "style": {"bold": true}},
+                {"text": "Col2", "style": {"bold": true}}
+            ]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var row = Assert.IsType<TableRow>(element);
+
+        Assert.NotNull(row.TableRowProperties?.GetFirstChild<TableHeader>());
+        var cells = row.Elements<TableCell>().ToList();
+        Assert.Equal(2, cells.Count);
+        Assert.Equal("Col1", cells[0].InnerText);
+    }
+
+    [Fact]
+    public void CreateCellAsTopLevelType()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "cell",
+            "text": "Cell content",
+            "shading": "E0E0E0",
+            "width": 2000,
+            "vertical_align": "center"
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var cell = Assert.IsType<TableCell>(element);
+
+        Assert.Equal("Cell content", cell.InnerText);
+        Assert.Equal("E0E0E0", cell.TableCellProperties?.Shading?.Fill?.Value);
+        Assert.Equal("2000", cell.TableCellProperties?.TableCellWidth?.Width?.Value);
+        Assert.Equal(TableVerticalAlignmentValues.Center,
+            cell.TableCellProperties?.TableCellVerticalAlignment?.Val?.Value);
+    }
+
+    [Fact]
+    public void CreateCellWithRunsArray()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "cell",
+            "runs": [
+                {"text": "Bold ", "style": {"bold": true}},
+                {"text": "normal"}
+            ]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var cell = Assert.IsType<TableCell>(element);
+
+        var runs = cell.Descendants<Run>().ToList();
+        Assert.Equal(2, runs.Count);
+        Assert.NotNull(runs[0].RunProperties?.Bold);
+        Assert.Equal("Bold ", runs[0].InnerText);
+        Assert.Equal("normal", runs[1].InnerText);
+    }
+
+    [Fact]
+    public void CreateCellWithMultipleParagraphs()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "cell",
+            "paragraphs": [
+                {"type": "paragraph", "text": "First paragraph"},
+                {"type": "paragraph", "text": "Second paragraph", "style": {"bold": true}}
+            ]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var cell = Assert.IsType<TableCell>(element);
+        var paragraphs = cell.Elements<Paragraph>().ToList();
+
+        Assert.Equal(2, paragraphs.Count);
+        Assert.Equal("First paragraph", paragraphs[0].InnerText);
+        Assert.Equal("Second paragraph", paragraphs[1].InnerText);
+    }
+
+    [Fact]
+    public void CreateTableWithRowHeight()
+    {
+        var mainPart = _session.Document.MainDocumentPart!;
+        var value = JsonDocument.Parse("""
+        {
+            "type": "table",
+            "rows": [
+                {
+                    "height": 500,
+                    "cells": [{"text": "Tall row"}]
+                }
+            ]
+        }
+        """).RootElement;
+
+        var element = ElementFactory.CreateFromJson(value, mainPart);
+        var table = Assert.IsType<Table>(element);
+        var row = table.Elements<TableRow>().First();
+
+        Assert.Equal(500u,
+            row.TableRowProperties?.GetFirstChild<TableRowHeight>()?.Val?.Value);
+    }
+
+    // ===========================
+    // Patch Operations on Tables
+    // ===========================
+
+    [Fact]
+    public void RemoveTableRow()
+    {
+        var result = PatchTool.ApplyPatch(_sessions, _session.Id,
+            """[{"op": "remove", "path": "/body/table[0]/row[2]"}]""");
+
+        Assert.Contains("Applied 1 patch(es) successfully", result);
+
+        var table = _session.GetBody().Elements<Table>().First();
+        var rows = table.Elements<TableRow>().ToList();
+        Assert.Equal(2, rows.Count); // header + 1 data row (removed "Bob" row)
+    }
+
+    [Fact]
+    public void RemoveTableCell()
+    {
+        var result = PatchTool.ApplyPatch(_sessions, _session.Id,
+            """[{"op": "remove", "path": "/body/table[0]/row[1]/cell[2]"}]""");
+
+        Assert.Contains("Applied 1 patch(es) successfully", result);
+
+        var table = _session.GetBody().Elements<Table>().First();
+        var row = table.Elements<TableRow>().ElementAt(1);
+        var cells = row.Elements<TableCell>().ToList();
+        Assert.Equal(2, cells.Count); // "Alice", "30" (removed "Paris")
+    }
+
+    [Fact]
+    public void ReplaceTableCell()
+    {
+        var result = PatchTool.ApplyPatch(_sessions, _session.Id, """
+        [{
+            "op": "replace",
+            "path": "/body/table[0]/row[1]/cell[0]",
+            "value": {
+                "type": "cell",
+                "text": "Alice Smith",
+                "style": {"bold": true},
+                "shading": "E0FFE0"
+            }
+        }]
+        """);
+
+        Assert.Contains("Applied 1 patch(es) successfully", result);
+
+        var table = _session.GetBody().Elements<Table>().First();
+        var cell = table.Elements<TableRow>().ElementAt(1).Elements<TableCell>().First();
+        Assert.Equal("Alice Smith", cell.InnerText);
+        Assert.Equal("E0FFE0", cell.TableCellProperties?.Shading?.Fill?.Value);
+    }
+
+    [Fact]
+    public void ReplaceTableRow()
+    {
+        var result = PatchTool.ApplyPatch(_sessions, _session.Id, """
+        [{
+            "op": "replace",
+            "path": "/body/table[0]/row[2]",
+            "value": {
+                "type": "row",
+                "cells": [
+                    {"text": "Charlie", "style": {"italic": true}},
+                    {"text": "35"},
+                    {"text": "Berlin"}
+                ]
+            }
+        }]
+        """);
+
+        Assert.Contains("Applied 1 patch(es) successfully", result);
+
+        var table = _session.GetBody().Elements<Table>().First();
+        var row = table.Elements<TableRow>().Last();
+        var cells = row.Elements<TableCell>().ToList();
+        Assert.Equal("Charlie", cells[0].InnerText);
+        Assert.Equal("35", cells[1].InnerText);
+        Assert.Equal("Berlin", cells[2].InnerText);
+    }
+
+    [Fact]
+    public void RemoveColumn()
+    {
+        var result = PatchTool.ApplyPatch(_sessions, _session.Id,
+            """[{"op": "remove_column", "path": "/body/table[0]", "column": 1}]""");
+
+        Assert.Contains("Applied 1 patch(es) successfully", result);
+
+        var table = _session.GetBody().Elements<Table>().First();
+        foreach (var row in table.Elements<TableRow>())
+        {
+            var cells = row.Elements<TableCell>().ToList();
+            Assert.Equal(2, cells.Count); // removed "Age" column
+        }
+
+        // Verify header: Name, City
+        var headerCells = table.Elements<TableRow>().First().Elements<TableCell>().ToList();
+        Assert.Equal("Name", headerCells[0].InnerText);
+        Assert.Equal("City", headerCells[1].InnerText);
+    }
+
+    [Fact]
+    public void RemoveFirstColumn()
+    {
+        var result = PatchTool.ApplyPatch(_sessions, _session.Id,
+            """[{"op": "remove_column", "path": "/body/table[0]", "column": 0}]""");
+
+        Assert.Contains("Applied 1 patch(es) successfully", result);
+
+        var table = _session.GetBody().Elements<Table>().First();
+        var headerCells = table.Elements<TableRow>().First().Elements<TableCell>().ToList();
+        Assert.Equal("Age", headerCells[0].InnerText);
+        Assert.Equal("City", headerCells[1].InnerText);
+    }
+
+    [Fact]
+    public void RemoveLastColumn()
+    {
+        var result = PatchTool.ApplyPatch(_sessions, _session.Id,
+            """[{"op": "remove_column", "path": "/body/table[0]", "column": 2}]""");
+
+        Assert.Contains("Applied 1 patch(es) successfully", result);
+
+        var table = _session.GetBody().Elements<Table>().First();
+        var headerCells = table.Elements<TableRow>().First().Elements<TableCell>().ToList();
+        Assert.Equal("Name", headerCells[0].InnerText);
+        Assert.Equal("Age", headerCells[1].InnerText);
+    }
+
+    [Fact]
+    public void ReplaceTextPreservesFormatting()
+    {
+        // First, add a styled paragraph with multiple runs
+        var body = _session.GetBody();
+        var p = new Paragraph(
+            new Run(
+                new RunProperties(new Bold(), new Color { Val = "FF0000" }),
+                new Text("Hello World") { Space = SpaceProcessingModeValues.Preserve }),
+            new Run(
+                new RunProperties(new Italic()),
+                new Text(" is great") { Space = SpaceProcessingModeValues.Preserve }));
+        body.AppendChild(p);
+
+        var result = PatchTool.ApplyPatch(_sessions, _session.Id, """
+        [{
+            "op": "replace_text",
+            "path": "/body/paragraph[text~='Hello World']",
+            "find": "World",
+            "replace": "Universe"
+        }]
+        """);
+
+        Assert.Contains("Applied 1 patch(es) successfully", result);
+
+        // Find the paragraph that was modified
+        var modified = body.Elements<Paragraph>()
+            .FirstOrDefault(par => par.InnerText.Contains("Universe"));
+        Assert.NotNull(modified);
+
+        // Verify the formatting is preserved
+        var runs = modified!.Elements<Run>().ToList();
+        Assert.True(runs.Count >= 1);
+
+        // First run should still be bold+red
+        var firstRun = runs[0];
+        Assert.NotNull(firstRun.RunProperties?.Bold);
+        Assert.Equal("FF0000", firstRun.RunProperties?.Color?.Val?.Value);
+        Assert.Contains("Universe", firstRun.InnerText);
+    }
+
+    [Fact]
+    public void ReplaceTextInTableCell()
+    {
+        var result = PatchTool.ApplyPatch(_sessions, _session.Id, """
+        [{
+            "op": "replace_text",
+            "path": "/body/table[0]/row[1]/cell[0]",
+            "find": "Alice",
+            "replace": "Eve"
+        }]
+        """);
+
+        Assert.Contains("Applied 1 patch(es) successfully", result);
+
+        var table = _session.GetBody().Elements<Table>().First();
+        var cell = table.Elements<TableRow>().ElementAt(1).Elements<TableCell>().First();
+        Assert.Equal("Eve", cell.InnerText);
+    }
+
+    [Fact]
+    public void AddRowToExistingTable()
+    {
+        // Add a new row after the last row
+        var result = PatchTool.ApplyPatch(_sessions, _session.Id, """
+        [{
+            "op": "add",
+            "path": "/body/table[0]",
+            "value": {
+                "type": "row",
+                "cells": ["Charlie", "35", "Berlin"]
+            }
+        }]
+        """);
+
+        Assert.Contains("Applied 1 patch(es) successfully", result);
+
+        var table = _session.GetBody().Elements<Table>().First();
+        var rows = table.Elements<TableRow>().ToList();
+        Assert.Equal(4, rows.Count); // header + 3 data rows
+
+        var lastRowCells = rows[3].Elements<TableCell>().ToList();
+        Assert.Equal("Charlie", lastRowCells[0].InnerText);
+    }
+
+    [Fact]
+    public void AddStyledCellToRow()
+    {
+        // Add a new cell to the first data row
+        var result = PatchTool.ApplyPatch(_sessions, _session.Id, """
+        [{
+            "op": "add",
+            "path": "/body/table[0]/row[1]",
+            "value": {
+                "type": "cell",
+                "text": "France",
+                "shading": "E0FFE0"
+            }
+        }]
+        """);
+
+        Assert.Contains("Applied 1 patch(es) successfully", result);
+
+        var table = _session.GetBody().Elements<Table>().First();
+        var row = table.Elements<TableRow>().ElementAt(1);
+        var cells = row.Elements<TableCell>().ToList();
+        Assert.Equal(4, cells.Count); // original 3 + new cell
+        Assert.Equal("France", cells[3].InnerText);
+    }
+
+    // ===========================
+    // Query Round-Trip Tests
+    // ===========================
+
+    [Fact]
+    public void QueryTableReturnsRichRowData()
+    {
+        var result = QueryTool.Query(_sessions, _session.Id, "/body/table[0]");
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+
+        Assert.Equal("table", root.GetProperty("type").GetString());
+        Assert.Equal(3, root.GetProperty("rows").GetInt32());
+        Assert.Equal(3, root.GetProperty("cols").GetInt32());
+
+        // Check rich_rows array
+        Assert.True(root.TryGetProperty("rich_rows", out var richRows));
+        Assert.Equal(3, richRows.GetArrayLength());
+
+        // Check first row (header) has is_header property
+        var firstRow = richRows[0];
+        Assert.True(firstRow.TryGetProperty("properties", out var rowProps));
+        Assert.True(rowProps.GetProperty("is_header").GetBoolean());
+    }
+
+    [Fact]
+    public void QueryCellReturnsProperties()
+    {
+        // Add a cell with shading for testing
+        var body = _session.GetBody();
+        var table = body.Elements<Table>().First();
+        var row = table.Elements<TableRow>().ElementAt(1);
+        var cell = row.Elements<TableCell>().First();
+
+        // Add cell properties
+        cell.TableCellProperties = new TableCellProperties(
+            new Shading { Fill = "AABBCC", Val = ShadingPatternValues.Clear },
+            new TableCellVerticalAlignment { Val = TableVerticalAlignmentValues.Center });
+
+        var result = QueryTool.Query(_sessions, _session.Id,
+            "/body/table[0]/row[1]/cell[0]");
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+
+        Assert.Equal("cell", root.GetProperty("type").GetString());
+        Assert.Equal("Alice", root.GetProperty("text").GetString());
+
+        Assert.True(root.TryGetProperty("properties", out var props));
+        Assert.Equal("AABBCC", props.GetProperty("shading").GetString());
+        Assert.Equal("center", props.GetProperty("vertical_align").GetString());
+    }
+
+    [Fact]
+    public void QueryTableReturnsTableProperties()
+    {
+        // Add table width and alignment
+        var table = _session.GetBody().Elements<Table>().First();
+        var tblProps = table.GetFirstChild<TableProperties>()!;
+        tblProps.TableWidth = new TableWidth { Width = "5000", Type = TableWidthUnitValues.Pct };
+        tblProps.TableJustification = new TableJustification { Val = TableRowAlignmentValues.Center };
+
+        var result = QueryTool.Query(_sessions, _session.Id, "/body/table[0]");
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+
+        Assert.True(root.TryGetProperty("properties", out var props));
+        Assert.Equal("5000", props.GetProperty("width").GetString());
+        Assert.Equal("center", props.GetProperty("table_alignment").GetString());
+    }
+
+    [Fact]
+    public void ReplaceTableProperties()
+    {
+        var result = PatchTool.ApplyPatch(_sessions, _session.Id, """
+        [{
+            "op": "replace",
+            "path": "/body/table[0]/style",
+            "value": {
+                "border_style": "double",
+                "width": 9000,
+                "table_alignment": "center"
+            }
+        }]
+        """);
+
+        Assert.Contains("Applied 1 patch(es) successfully", result);
+
+        var table = _session.GetBody().Elements<Table>().First();
+        var tblProps = table.GetFirstChild<TableProperties>();
+        Assert.NotNull(tblProps);
+        Assert.Equal(BorderValues.Double, tblProps!.TableBorders?.TopBorder?.Val?.Value);
+        Assert.Equal("9000", tblProps.TableWidth?.Width?.Value);
+        Assert.Equal(TableRowAlignmentValues.Center, tblProps.TableJustification?.Val?.Value);
+    }
+
+    [Fact]
+    public void MultiplePatchOperationsOnTable()
+    {
+        // Do multiple operations in one patch call:
+        // 1. Replace header cell text
+        // 2. Remove a column
+        // 3. Add a new row
+        var result = PatchTool.ApplyPatch(_sessions, _session.Id, """
+        [
+            {
+                "op": "replace_text",
+                "path": "/body/table[0]/row[0]/cell[0]",
+                "find": "Name",
+                "replace": "Full Name"
+            },
+            {
+                "op": "remove_column",
+                "path": "/body/table[0]",
+                "column": 2
+            }
+        ]
+        """);
+
+        Assert.Contains("Applied 2 patch(es) successfully", result);
+
+        var table = _session.GetBody().Elements<Table>().First();
+
+        // Verify header text changed
+        var headerCells = table.Elements<TableRow>().First().Elements<TableCell>().ToList();
+        Assert.Equal("Full Name", headerCells[0].InnerText);
+
+        // Verify column removed (2 columns left)
+        Assert.Equal(2, headerCells.Count);
+    }
+
+    public void Dispose()
+    {
+        _sessions.Close(_session.Id);
+    }
+}


### PR DESCRIPTION
…rip fidelity

Add full run-level write support so paragraphs and headings can be created with per-run styling (bold, italic, font_size, font_name, color), tab characters, and line/page/column breaks. Add paragraph properties support (alignment, spacing, indentation, tab stops). Implement rich table creation with styled cells, shading, col_span/row_span, borders, and row/cell as top-level patch types. Add replace_text (format-preserving find/replace) and remove_column patch operations. Enhance query output to always emit runs array, detect tabs/breaks, and include full table structure with rich_rows/rich_cells. Add 58 new unit tests (101 total) and expand integration test script with real document tests.