### PR TITLE
feat: koyeb deployment with SSE transport and oauth authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,73 @@
+# docx-mcp Environment Configuration
+# Copy this file to .env and fill in the values
+
+# =============================================================================
+# TRANSPORT MODE
+# =============================================================================
+# "stdio" for traditional MCP (local clients like Claude Desktop)
+# "sse" or "http" for cloud deployment (Koyeb, etc.)
+DOCX_MCP_TRANSPORT=stdio
+
+# =============================================================================
+# STORAGE PROVIDER
+# =============================================================================
+# "local" - Local filesystem (default, good for development and Docker volumes)
+# "gcs" - Google Cloud Storage (recommended for Koyeb/cloud)
+DOCX_MCP_STORAGE_PROVIDER=local
+
+# Local storage path (used when DOCX_MCP_STORAGE_PROVIDER=local)
+# Defaults to ~/.docx-mcp/sessions if not set
+DOCX_MCP_SESSIONS_DIR=
+
+# =============================================================================
+# GOOGLE CLOUD STORAGE (when DOCX_MCP_STORAGE_PROVIDER=gcs)
+# =============================================================================
+# GCS bucket name (required)
+GCS_BUCKET=my-docx-mcp-bucket
+
+# Object prefix for all stored files
+GCS_PREFIX=docx-mcp/sessions/
+
+# Path to service account JSON (optional if using workload identity/ADC)
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+
+# =============================================================================
+# OAUTH / MICROSOFT ENTRA ID
+# =============================================================================
+# Azure AD tenant ID
+# Use "common" for multi-tenant, or a specific tenant GUID
+AZURE_TENANT_ID=common
+
+# Application (client) ID from Azure AD app registration
+AZURE_CLIENT_ID=
+
+# Client secret (for confidential client flow)
+AZURE_CLIENT_SECRET=
+
+# Base URL for this service (used for OAuth redirect URI)
+# In production, this should be your public URL
+DOCX_MCP_BASE_URL=http://localhost:8080
+
+# Set to "false" to disable token validation (development only!)
+DOCX_MCP_VALIDATE_TOKENS=true
+
+# =============================================================================
+# HTTP SERVER (when running in SSE mode)
+# =============================================================================
+# Port to listen on (Koyeb sets PORT automatically)
+PORT=8080
+
+# CORS allowed origins (comma-separated, or "*" for all)
+DOCX_MCP_CORS_ORIGINS=*
+
+# =============================================================================
+# SESSION MANAGEMENT
+# =============================================================================
+# Checkpoint interval (create snapshot every N edits)
+DOCX_MCP_CHECKPOINT_INTERVAL=10
+
+# WAL compaction threshold (compact when WAL exceeds N entries)
+DOCX_MCP_WAL_COMPACT_THRESHOLD=50
+
+# Session max age in days (auto-cleanup stale sessions)
+DOCX_MCP_SESSION_MAX_AGE_DAYS=7

--- a/Dockerfile.koyeb
+++ b/Dockerfile.koyeb
@@ -1,0 +1,59 @@
+# Dockerfile optimized for Koyeb deployment with SSE transport
+# Supports both local and GCS storage backends
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0-preview AS build
+
+# NativeAOT requires clang as the platform linker
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends clang zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+
+# Copy project files first for better layer caching
+COPY *.sln ./
+COPY src/DocxMcp/DocxMcp.csproj src/DocxMcp/
+COPY src/DocxMcp.Cli/DocxMcp.Cli.csproj src/DocxMcp.Cli/
+COPY tests/DocxMcp.Tests/DocxMcp.Tests.csproj tests/DocxMcp.Tests/
+
+# Restore dependencies
+RUN dotnet restore
+
+# Copy source code
+COPY . .
+
+# Build MCP server (HTTP/SSE mode)
+RUN dotnet publish src/DocxMcp/DocxMcp.csproj \
+    --configuration Release \
+    --no-restore \
+    -o /app
+
+# Runtime: minimal image
+FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-preview AS runtime
+
+WORKDIR /app
+
+# Copy the built binary
+COPY --from=build /app/docx-mcp .
+
+# Create non-root user (runtime-deps already has 'app' user)
+RUN mkdir -p /home/app/.docx-mcp/sessions && \
+    chown -R app:app /home/app/.docx-mcp
+
+# Volume for local storage mode (optional on Koyeb)
+VOLUME /home/app/.docx-mcp/sessions
+
+USER app
+
+# Environment variables for Koyeb
+ENV DOCX_MCP_TRANSPORT=sse
+ENV DOCX_MCP_SESSIONS_DIR=/home/app/.docx-mcp/sessions
+# PORT is set by Koyeb automatically (default 8080)
+
+# Health check for Koyeb
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:${PORT:-8080}/health || exit 1
+
+EXPOSE 8080
+
+ENTRYPOINT ["./docx-mcp"]

--- a/koyeb.yaml
+++ b/koyeb.yaml
@@ -1,0 +1,92 @@
+# Koyeb deployment configuration for docx-mcp
+# Deploy with: koyeb deploy -f koyeb.yaml
+
+name: docx-mcp
+
+service:
+  name: docx-mcp
+  type: web
+
+  # Build from Dockerfile
+  docker:
+    dockerfile: Dockerfile.koyeb
+    # Or use pre-built image:
+    # image: ghcr.io/valdo404/docx-mcp:latest
+
+  # Instance configuration
+  instance_type: nano  # Upgrade for production
+  regions:
+    - par  # Paris (or fra, was, sgp, sfo)
+
+  # Scaling
+  scaling:
+    min: 1
+    max: 3
+
+  # Port configuration
+  ports:
+    - port: 8080
+      protocol: http
+
+  # Health check
+  health_checks:
+    - type: http
+      port: 8080
+      path: /health
+      interval: 30
+      timeout: 5
+      healthy_threshold: 2
+      unhealthy_threshold: 3
+
+  # Environment variables
+  env:
+    # Transport mode
+    - name: DOCX_MCP_TRANSPORT
+      value: "sse"
+
+    # Storage provider: "local" or "gcs"
+    - name: DOCX_MCP_STORAGE_PROVIDER
+      value: "gcs"
+
+    # GCS configuration (required if using gcs storage)
+    - name: GCS_BUCKET
+      value: ""  # Set your bucket name
+      # Or use secret: secret:gcs-bucket
+
+    - name: GCS_PREFIX
+      value: "docx-mcp/sessions/"
+
+    # OAuth configuration (Microsoft Entra ID)
+    # Use Koyeb secrets for sensitive values
+    - name: AZURE_TENANT_ID
+      value: "common"  # Or specific tenant ID
+
+    - name: AZURE_CLIENT_ID
+      secret: azure-client-id  # Create this secret in Koyeb
+
+    - name: AZURE_CLIENT_SECRET
+      secret: azure-client-secret  # Create this secret in Koyeb
+
+    # Base URL for OAuth callbacks
+    - name: DOCX_MCP_BASE_URL
+      value: "https://docx-mcp-<your-org>.koyeb.app"
+
+    # CORS origins (comma-separated)
+    - name: DOCX_MCP_CORS_ORIGINS
+      value: "*"
+
+    # GCS credentials (if not using workload identity)
+    # Mount the service account JSON as a secret
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: "/secrets/gcs-credentials.json"
+
+  # Secrets as files
+  volumes:
+    - name: gcs-credentials
+      secret: gcs-service-account
+      mount_path: /secrets
+
+  # Routes
+  routes:
+    - path: /
+      port: 8080

--- a/src/DocxMcp/Auth/OAuthOptions.cs
+++ b/src/DocxMcp/Auth/OAuthOptions.cs
@@ -1,0 +1,62 @@
+namespace DocxMcp.Auth;
+
+/// <summary>
+/// Configuration options for Microsoft Entra ID (Azure AD) OAuth.
+/// </summary>
+public sealed class OAuthOptions
+{
+    public const string SectionName = "AzureAd";
+
+    /// <summary>
+    /// Azure AD tenant ID. Use "common" for multi-tenant, or a specific tenant GUID.
+    /// </summary>
+    public string TenantId { get; set; } = "common";
+
+    /// <summary>
+    /// Application (client) ID from Azure AD app registration.
+    /// </summary>
+    public string ClientId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Client secret for confidential client flow.
+    /// </summary>
+    public string ClientSecret { get; set; } = string.Empty;
+
+    /// <summary>
+    /// OAuth scopes to request. Defaults include Graph API access for OneDrive/SharePoint.
+    /// </summary>
+    public string[] Scopes { get; set; } = new[]
+    {
+        "openid",
+        "profile",
+        "email",
+        "offline_access",
+        "Files.ReadWrite.All",    // OneDrive personal files
+        "Sites.ReadWrite.All"     // SharePoint sites
+    };
+
+    /// <summary>
+    /// Base URL for this service (used for redirect URI).
+    /// </summary>
+    public string BaseUrl { get; set; } = "http://localhost:8080";
+
+    /// <summary>
+    /// Redirect path after OAuth callback.
+    /// </summary>
+    public string RedirectPath { get; set; } = "/auth/callback";
+
+    /// <summary>
+    /// Full redirect URI for OAuth flow.
+    /// </summary>
+    public string RedirectUri => $"{BaseUrl.TrimEnd('/')}{RedirectPath}";
+
+    /// <summary>
+    /// Authority URL for Microsoft identity platform.
+    /// </summary>
+    public string Authority => $"https://login.microsoftonline.com/{TenantId}/v2.0";
+
+    /// <summary>
+    /// Whether to validate tokens (disable only for development).
+    /// </summary>
+    public bool ValidateTokens { get; set; } = true;
+}

--- a/src/DocxMcp/Auth/TokenService.cs
+++ b/src/DocxMcp/Auth/TokenService.cs
@@ -1,0 +1,260 @@
+using System.Collections.Concurrent;
+using System.IdentityModel.Tokens.Jwt;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace DocxMcp.Auth;
+
+/// <summary>
+/// Service for OAuth token exchange, validation, and refresh.
+/// Handles the OAuth 2.0 authorization code flow with Microsoft Entra ID.
+/// </summary>
+public sealed class TokenService
+{
+    private readonly OAuthOptions _options;
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<TokenService> _logger;
+    private readonly ConcurrentDictionary<string, TokenInfo> _tokenCache = new();
+
+    public TokenService(IOptions<OAuthOptions> options, HttpClient httpClient, ILogger<TokenService> logger)
+    {
+        _options = options.Value;
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Generate the authorization URL to redirect the user to Microsoft login.
+    /// </summary>
+    public string GetAuthorizationUrl(string state)
+    {
+        var scopes = string.Join(" ", _options.Scopes);
+        var authUrl = $"https://login.microsoftonline.com/{_options.TenantId}/oauth2/v2.0/authorize" +
+            $"?client_id={Uri.EscapeDataString(_options.ClientId)}" +
+            $"&response_type=code" +
+            $"&redirect_uri={Uri.EscapeDataString(_options.RedirectUri)}" +
+            $"&scope={Uri.EscapeDataString(scopes)}" +
+            $"&state={Uri.EscapeDataString(state)}" +
+            $"&response_mode=query";
+        return authUrl;
+    }
+
+    /// <summary>
+    /// Exchange an authorization code for access and refresh tokens.
+    /// </summary>
+    public async Task<TokenInfo?> ExchangeCodeAsync(string code, CancellationToken ct = default)
+    {
+        var tokenEndpoint = $"https://login.microsoftonline.com/{_options.TenantId}/oauth2/v2.0/token";
+
+        var content = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["client_id"] = _options.ClientId,
+            ["client_secret"] = _options.ClientSecret,
+            ["code"] = code,
+            ["redirect_uri"] = _options.RedirectUri,
+            ["grant_type"] = "authorization_code",
+            ["scope"] = string.Join(" ", _options.Scopes)
+        });
+
+        try
+        {
+            var response = await _httpClient.PostAsync(tokenEndpoint, content, ct);
+            var json = await response.Content.ReadAsStringAsync(ct);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError("Token exchange failed: {StatusCode} {Response}", response.StatusCode, json);
+                return null;
+            }
+
+            var tokenResponse = JsonSerializer.Deserialize<TokenResponse>(json);
+            if (tokenResponse is null)
+                return null;
+
+            var tokenInfo = new TokenInfo
+            {
+                AccessToken = tokenResponse.access_token ?? string.Empty,
+                RefreshToken = tokenResponse.refresh_token ?? string.Empty,
+                ExpiresAt = DateTime.UtcNow.AddSeconds(tokenResponse.expires_in - 60), // 60s buffer
+                Scopes = tokenResponse.scope?.Split(' ') ?? Array.Empty<string>()
+            };
+
+            // Cache the token by user ID extracted from JWT
+            var userId = ExtractUserIdFromToken(tokenInfo.AccessToken);
+            if (!string.IsNullOrEmpty(userId))
+            {
+                _tokenCache[userId] = tokenInfo;
+            }
+
+            return tokenInfo;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to exchange authorization code for tokens");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Refresh an access token using a refresh token.
+    /// </summary>
+    public async Task<TokenInfo?> RefreshTokenAsync(string refreshToken, CancellationToken ct = default)
+    {
+        var tokenEndpoint = $"https://login.microsoftonline.com/{_options.TenantId}/oauth2/v2.0/token";
+
+        var content = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["client_id"] = _options.ClientId,
+            ["client_secret"] = _options.ClientSecret,
+            ["refresh_token"] = refreshToken,
+            ["grant_type"] = "refresh_token",
+            ["scope"] = string.Join(" ", _options.Scopes)
+        });
+
+        try
+        {
+            var response = await _httpClient.PostAsync(tokenEndpoint, content, ct);
+            var json = await response.Content.ReadAsStringAsync(ct);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError("Token refresh failed: {StatusCode} {Response}", response.StatusCode, json);
+                return null;
+            }
+
+            var tokenResponse = JsonSerializer.Deserialize<TokenResponse>(json);
+            if (tokenResponse is null)
+                return null;
+
+            return new TokenInfo
+            {
+                AccessToken = tokenResponse.access_token ?? string.Empty,
+                RefreshToken = tokenResponse.refresh_token ?? refreshToken, // Keep old if not returned
+                ExpiresAt = DateTime.UtcNow.AddSeconds(tokenResponse.expires_in - 60),
+                Scopes = tokenResponse.scope?.Split(' ') ?? Array.Empty<string>()
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to refresh token");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Validate a bearer token and extract claims.
+    /// </summary>
+    public ClaimsPrincipal? ValidateToken(string token)
+    {
+        try
+        {
+            var handler = new JwtSecurityTokenHandler();
+
+            // For Microsoft tokens, we do basic validation
+            // Full validation with keys would require fetching JWKS
+            if (!handler.CanReadToken(token))
+                return null;
+
+            var jwt = handler.ReadJwtToken(token);
+
+            // Check expiration
+            if (jwt.ValidTo < DateTime.UtcNow)
+            {
+                _logger.LogWarning("Token has expired");
+                return null;
+            }
+
+            // Check audience (client ID)
+            var audience = jwt.Claims.FirstOrDefault(c => c.Type == "aud")?.Value;
+            if (_options.ValidateTokens && audience != _options.ClientId)
+            {
+                _logger.LogWarning("Token audience mismatch: expected {Expected}, got {Actual}",
+                    _options.ClientId, audience);
+                return null;
+            }
+
+            // Build ClaimsPrincipal
+            var identity = new ClaimsIdentity(jwt.Claims, "Bearer");
+            return new ClaimsPrincipal(identity);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Token validation failed");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Get a valid access token for a user, refreshing if necessary.
+    /// </summary>
+    public async Task<string?> GetValidAccessTokenAsync(string userId, CancellationToken ct = default)
+    {
+        if (!_tokenCache.TryGetValue(userId, out var tokenInfo))
+            return null;
+
+        // If token is still valid, return it
+        if (tokenInfo.ExpiresAt > DateTime.UtcNow)
+            return tokenInfo.AccessToken;
+
+        // Try to refresh
+        if (!string.IsNullOrEmpty(tokenInfo.RefreshToken))
+        {
+            var newToken = await RefreshTokenAsync(tokenInfo.RefreshToken, ct);
+            if (newToken is not null)
+            {
+                _tokenCache[userId] = newToken;
+                return newToken.AccessToken;
+            }
+        }
+
+        // Token expired and refresh failed
+        _tokenCache.TryRemove(userId, out _);
+        return null;
+    }
+
+    /// <summary>
+    /// Store a token for a user.
+    /// </summary>
+    public void StoreToken(string userId, TokenInfo tokenInfo)
+    {
+        _tokenCache[userId] = tokenInfo;
+    }
+
+    private static string? ExtractUserIdFromToken(string token)
+    {
+        try
+        {
+            var handler = new JwtSecurityTokenHandler();
+            var jwt = handler.ReadJwtToken(token);
+            return jwt.Claims.FirstOrDefault(c => c.Type == "oid")?.Value
+                ?? jwt.Claims.FirstOrDefault(c => c.Type == "sub")?.Value;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private sealed class TokenResponse
+    {
+        public string? access_token { get; set; }
+        public string? refresh_token { get; set; }
+        public int expires_in { get; set; }
+        public string? scope { get; set; }
+        public string? token_type { get; set; }
+    }
+}
+
+/// <summary>
+/// Holds OAuth token information.
+/// </summary>
+public sealed class TokenInfo
+{
+    public string AccessToken { get; init; } = string.Empty;
+    public string RefreshToken { get; init; } = string.Empty;
+    public DateTime ExpiresAt { get; init; }
+    public string[] Scopes { get; init; } = Array.Empty<string>();
+}

--- a/src/DocxMcp/Auth/UserContext.cs
+++ b/src/DocxMcp/Auth/UserContext.cs
@@ -1,0 +1,66 @@
+using System.Security.Claims;
+
+namespace DocxMcp.Auth;
+
+/// <summary>
+/// Represents the authenticated user context for the current request.
+/// Provides access to user identity, tokens, and Microsoft Graph credentials.
+/// </summary>
+public sealed class UserContext
+{
+    /// <summary>
+    /// Unique user identifier (object ID from Azure AD).
+    /// </summary>
+    public string UserId { get; init; } = string.Empty;
+
+    /// <summary>
+    /// User's email address.
+    /// </summary>
+    public string Email { get; init; } = string.Empty;
+
+    /// <summary>
+    /// User's display name.
+    /// </summary>
+    public string DisplayName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Tenant ID the user belongs to.
+    /// </summary>
+    public string TenantId { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Access token for Microsoft Graph API calls.
+    /// </summary>
+    public string AccessToken { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Whether the user is authenticated.
+    /// </summary>
+    public bool IsAuthenticated => !string.IsNullOrEmpty(UserId);
+
+    /// <summary>
+    /// Create a UserContext from ClaimsPrincipal and access token.
+    /// </summary>
+    public static UserContext FromClaimsPrincipal(ClaimsPrincipal principal, string accessToken)
+    {
+        return new UserContext
+        {
+            UserId = principal.FindFirstValue("oid")
+                  ?? principal.FindFirstValue(ClaimTypes.NameIdentifier)
+                  ?? string.Empty,
+            Email = principal.FindFirstValue("preferred_username")
+                 ?? principal.FindFirstValue(ClaimTypes.Email)
+                 ?? string.Empty,
+            DisplayName = principal.FindFirstValue("name")
+                       ?? principal.FindFirstValue(ClaimTypes.Name)
+                       ?? string.Empty,
+            TenantId = principal.FindFirstValue("tid") ?? string.Empty,
+            AccessToken = accessToken
+        };
+    }
+
+    /// <summary>
+    /// Create an anonymous (unauthenticated) context.
+    /// </summary>
+    public static UserContext Anonymous => new();
+}

--- a/src/DocxMcp/DocxMcp.csproj
+++ b/src/DocxMcp/DocxMcp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -20,6 +20,21 @@
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.2.0" />
     <PackageReference Include="ModelContextProtocol" Version="0.7.0-preview.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+
+    <!-- OAuth / Microsoft Identity -->
+    <PackageReference Include="Microsoft.Identity.Web" Version="3.8.0" />
+
+    <!-- Microsoft Graph SDK for OneDrive/SharePoint -->
+    <PackageReference Include="Microsoft.Graph" Version="5.75.0" />
+
+    <!-- JWT Bearer token validation -->
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.1" />
+
+    <!-- Google Cloud Storage -->
+    <PackageReference Include="Google.Cloud.Storage.V1" Version="4.10.0" />
+
+    <!-- JWT token handling -->
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/DocxMcp/Http/McpEndpoints.cs
+++ b/src/DocxMcp/Http/McpEndpoints.cs
@@ -1,0 +1,276 @@
+using System.Security.Claims;
+using System.Text.Json;
+using DocxMcp.Auth;
+using DocxMcp.Transport;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace DocxMcp.Http;
+
+/// <summary>
+/// HTTP endpoint definitions for the MCP SSE server.
+/// </summary>
+public static class McpEndpoints
+{
+    /// <summary>
+    /// Map all MCP-related HTTP endpoints.
+    /// </summary>
+    public static IEndpointRouteBuilder MapMcpEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        // Health check
+        endpoints.MapGet("/health", HealthCheck)
+            .AllowAnonymous()
+            .WithName("Health")
+            .WithTags("System");
+
+        // OAuth endpoints
+        endpoints.MapGet("/auth/login", AuthLogin)
+            .AllowAnonymous()
+            .WithName("AuthLogin")
+            .WithTags("Auth");
+
+        endpoints.MapGet("/auth/callback", AuthCallback)
+            .AllowAnonymous()
+            .WithName("AuthCallback")
+            .WithTags("Auth");
+
+        endpoints.MapGet("/auth/me", AuthMe)
+            .RequireAuthorization()
+            .WithName("AuthMe")
+            .WithTags("Auth");
+
+        // SSE endpoint for MCP
+        endpoints.MapGet("/sse", SseConnect)
+            .RequireAuthorization()
+            .WithName("SseConnect")
+            .WithTags("MCP");
+
+        // Message endpoint for client→server communication
+        endpoints.MapPost("/message", PostMessage)
+            .RequireAuthorization()
+            .WithName("PostMessage")
+            .WithTags("MCP");
+
+        return endpoints;
+    }
+
+    /// <summary>
+    /// Health check endpoint for Koyeb and load balancers.
+    /// </summary>
+    private static IResult HealthCheck(IServiceProvider services)
+    {
+        var sessionManager = services.GetRequiredService<SessionManager>();
+        var activeSessions = sessionManager.List().Count;
+
+        return Results.Ok(new
+        {
+            status = "healthy",
+            timestamp = DateTime.UtcNow,
+            version = "2.1.0",
+            transport = "sse",
+            activeSessions
+        });
+    }
+
+    /// <summary>
+    /// Initiate OAuth login flow.
+    /// </summary>
+    private static IResult AuthLogin(
+        HttpContext context,
+        TokenService tokenService)
+    {
+        // Generate state for CSRF protection
+        var state = Guid.NewGuid().ToString("N");
+        context.Response.Cookies.Append("oauth_state", state, new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = true,
+            SameSite = SameSiteMode.Lax,
+            MaxAge = TimeSpan.FromMinutes(10)
+        });
+
+        var authUrl = tokenService.GetAuthorizationUrl(state);
+        return Results.Redirect(authUrl);
+    }
+
+    /// <summary>
+    /// OAuth callback handler.
+    /// </summary>
+    private static async Task<IResult> AuthCallback(
+        HttpContext context,
+        TokenService tokenService,
+        ILogger<TokenService> logger)
+    {
+        var code = context.Request.Query["code"].FirstOrDefault();
+        var state = context.Request.Query["state"].FirstOrDefault();
+        var error = context.Request.Query["error"].FirstOrDefault();
+
+        if (!string.IsNullOrEmpty(error))
+        {
+            var errorDescription = context.Request.Query["error_description"].FirstOrDefault();
+            logger.LogError("OAuth error: {Error} - {Description}", error, errorDescription);
+            return Results.BadRequest(new { error, description = errorDescription });
+        }
+
+        // Verify state
+        var storedState = context.Request.Cookies["oauth_state"];
+        if (string.IsNullOrEmpty(state) || state != storedState)
+        {
+            return Results.BadRequest(new { error = "invalid_state", description = "State mismatch - possible CSRF attack" });
+        }
+
+        if (string.IsNullOrEmpty(code))
+        {
+            return Results.BadRequest(new { error = "missing_code", description = "Authorization code not provided" });
+        }
+
+        // Exchange code for tokens
+        var tokenInfo = await tokenService.ExchangeCodeAsync(code);
+        if (tokenInfo is null)
+        {
+            return Results.BadRequest(new { error = "token_exchange_failed", description = "Failed to exchange authorization code" });
+        }
+
+        // Clear state cookie
+        context.Response.Cookies.Delete("oauth_state");
+
+        // Return token to client (in production, use secure cookies or return to SPA)
+        return Results.Ok(new
+        {
+            access_token = tokenInfo.AccessToken,
+            expires_at = tokenInfo.ExpiresAt,
+            message = "Authentication successful. Use this token in the Authorization header for SSE connections."
+        });
+    }
+
+    /// <summary>
+    /// Get current user info.
+    /// </summary>
+    private static IResult AuthMe(HttpContext context)
+    {
+        var user = context.User;
+        if (user.Identity?.IsAuthenticated != true)
+        {
+            return Results.Unauthorized();
+        }
+
+        return Results.Ok(new
+        {
+            userId = user.FindFirstValue("oid") ?? user.FindFirstValue(ClaimTypes.NameIdentifier),
+            email = user.FindFirstValue("preferred_username") ?? user.FindFirstValue(ClaimTypes.Email),
+            name = user.FindFirstValue("name") ?? user.FindFirstValue(ClaimTypes.Name),
+            tenantId = user.FindFirstValue("tid")
+        });
+    }
+
+    /// <summary>
+    /// Establish SSE connection for MCP protocol.
+    /// </summary>
+    private static async Task SseConnect(
+        HttpContext context,
+        SseTransport transport,
+        McpSseServer mcpServer,
+        ILogger<SseTransport> logger)
+    {
+        // Get user context
+        var accessToken = context.Request.Headers.Authorization.FirstOrDefault()?.Replace("Bearer ", "") ?? "";
+        var userContext = UserContext.FromClaimsPrincipal(context.User, accessToken);
+
+        if (!userContext.IsAuthenticated)
+        {
+            context.Response.StatusCode = 401;
+            await context.Response.WriteAsJsonAsync(new { error = "unauthorized" });
+            return;
+        }
+
+        // Create connection
+        var connectionId = Guid.NewGuid().ToString("N")[..12];
+        var connection = transport.CreateConnection(connectionId, userContext);
+
+        // Set SSE headers
+        context.Response.ContentType = "text/event-stream";
+        context.Response.Headers.CacheControl = "no-cache";
+        context.Response.Headers.Connection = "keep-alive";
+        context.Response.Headers["X-Accel-Buffering"] = "no"; // Disable nginx buffering
+
+        logger.LogInformation("SSE connection established: {ConnectionId} for user {UserId}",
+            connectionId, userContext.UserId);
+
+        try
+        {
+            // Start processing inbound messages in background
+            _ = ProcessInboundMessagesAsync(connection, mcpServer, context.RequestAborted);
+
+            // Stream SSE messages to client
+            await connection.StreamToResponseAsync(context.Response.Body, context.RequestAborted);
+        }
+        catch (OperationCanceledException)
+        {
+            logger.LogInformation("SSE connection closed: {ConnectionId}", connectionId);
+        }
+        finally
+        {
+            await transport.RemoveConnectionAsync(connectionId);
+        }
+    }
+
+    /// <summary>
+    /// Process inbound messages for a connection.
+    /// </summary>
+    private static async Task ProcessInboundMessagesAsync(
+        SseConnection connection,
+        McpSseServer mcpServer,
+        CancellationToken ct)
+    {
+        await foreach (var message in connection.ReadInboundAsync(ct))
+        {
+            var response = await mcpServer.ProcessMessageAsync(connection, message, ct);
+            if (response is not null)
+            {
+                await connection.SendJsonRpcAsync(response, ct);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Receive client→server message (paired with SSE).
+    /// </summary>
+    private static async Task<IResult> PostMessage(
+        HttpContext context,
+        SseTransport transport,
+        ILogger<SseTransport> logger)
+    {
+        // Get connection ID from header or query
+        var connectionId = context.Request.Headers["X-Connection-Id"].FirstOrDefault()
+            ?? context.Request.Query["connectionId"].FirstOrDefault();
+
+        if (string.IsNullOrEmpty(connectionId))
+        {
+            return Results.BadRequest(new { error = "missing_connection_id" });
+        }
+
+        var connection = transport.GetConnection(connectionId);
+        if (connection is null)
+        {
+            return Results.NotFound(new { error = "connection_not_found" });
+        }
+
+        // Verify user owns this connection
+        var userId = context.User.FindFirstValue("oid") ?? context.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (connection.User.UserId != userId)
+        {
+            return Results.Forbid();
+        }
+
+        // Read message body
+        using var document = await JsonDocument.ParseAsync(context.Request.Body, cancellationToken: context.RequestAborted);
+
+        // Queue message for processing
+        await connection.ReceiveAsync(document, context.RequestAborted);
+
+        return Results.Accepted();
+    }
+}

--- a/src/DocxMcp/Program.cs
+++ b/src/DocxMcp/Program.cs
@@ -1,57 +1,257 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
 using ModelContextProtocol.Server;
 using DocxMcp;
+using DocxMcp.Auth;
+using DocxMcp.Http;
 using DocxMcp.Persistence;
+using DocxMcp.Storage;
 using DocxMcp.Tools;
 using DocxMcp.ExternalChanges;
+using DocxMcp.Transport;
 
-var builder = Host.CreateApplicationBuilder(args);
+// Determine transport mode from environment
+var transportMode = Environment.GetEnvironmentVariable("DOCX_MCP_TRANSPORT")?.ToLowerInvariant() ?? "stdio";
 
-// MCP requirement: all logging goes to stderr
-builder.Logging.AddConsole(options =>
+if (transportMode == "sse" || transportMode == "http")
 {
-    options.LogToStandardErrorThreshold = LogLevel.Trace;
-});
+    await RunHttpServerAsync(args);
+}
+else
+{
+    await RunStdioServerAsync(args);
+}
 
-// Register persistence and session management
-builder.Services.AddSingleton<SessionStore>();
-builder.Services.AddSingleton<SessionManager>();
-builder.Services.AddHostedService<SessionRestoreService>();
+/// <summary>
+/// Run the MCP server in stdio mode (traditional MCP, for local clients).
+/// </summary>
+static async Task RunStdioServerAsync(string[] args)
+{
+    var builder = Host.CreateApplicationBuilder(args);
 
-// Register external change tracking
-builder.Services.AddSingleton<ExternalChangeTracker>();
-builder.Services.AddHostedService<ExternalChangeNotificationService>();
-
-// Register MCP server with stdio transport and explicit tool types (AOT-safe)
-builder.Services
-    .AddMcpServer(options =>
+    // MCP requirement: all logging goes to stderr
+    builder.Logging.AddConsole(options =>
     {
-        options.ServerInfo = new()
-        {
-            Name = "docx-mcp",
-            Version = "2.2.0"
-        };
-    })
-    .WithStdioServerTransport()
-    // Document management
-    .WithTools<DocumentTools>()
-    // Query tools
-    .WithTools<QueryTool>()
-    .WithTools<CountTool>()
-    .WithTools<ReadSectionTool>()
-    .WithTools<ReadHeadingContentTool>()
-    // Element operations (individual tools with focused documentation)
-    .WithTools<ElementTools>()
-    .WithTools<TextTools>()
-    .WithTools<TableTools>()
-    // Export, history, comments, styles
-    .WithTools<ExportTools>()
-    .WithTools<HistoryTools>()
-    .WithTools<CommentTools>()
-    .WithTools<StyleTools>()
-    .WithTools<RevisionTools>()
-    .WithTools<ExternalChangeTools>();
+        options.LogToStandardErrorThreshold = LogLevel.Trace;
+    });
 
-await builder.Build().RunAsync();
+    // Register persistence and session management
+    builder.Services.AddSingleton<SessionStore>();
+    builder.Services.AddSingleton<SessionManager>();
+    builder.Services.AddHostedService<SessionRestoreService>();
+
+    // Register external change tracking
+    builder.Services.AddSingleton<ExternalChangeTracker>();
+    builder.Services.AddHostedService<ExternalChangeNotificationService>();
+
+    // Register MCP server with stdio transport and explicit tool types (AOT-safe)
+    builder.Services
+        .AddMcpServer(options =>
+        {
+            options.ServerInfo = new()
+            {
+                Name = "docx-mcp",
+                Version = "2.2.0"
+            };
+        })
+        .WithStdioServerTransport()
+        // Document management
+        .WithTools<DocumentTools>()
+        // Query tools
+        .WithTools<QueryTool>()
+        .WithTools<CountTool>()
+        .WithTools<ReadSectionTool>()
+        .WithTools<ReadHeadingContentTool>()
+        // Element operations (individual tools with focused documentation)
+        .WithTools<ElementTools>()
+        .WithTools<TextTools>()
+        .WithTools<TableTools>()
+        // Export, history, comments, styles
+        .WithTools<ExportTools>()
+        .WithTools<HistoryTools>()
+        .WithTools<CommentTools>()
+        .WithTools<StyleTools>()
+        .WithTools<RevisionTools>()
+        .WithTools<ExternalChangeTools>();
+
+    await builder.Build().RunAsync();
+}
+
+/// <summary>
+/// Run the MCP server in HTTP/SSE mode (for cloud deployment like Koyeb).
+/// </summary>
+static async Task RunHttpServerAsync(string[] args)
+{
+    var builder = WebApplication.CreateBuilder(args);
+
+    // Configuration
+    builder.Services.Configure<OAuthOptions>(options =>
+    {
+        options.TenantId = Environment.GetEnvironmentVariable("AZURE_TENANT_ID") ?? "common";
+        options.ClientId = Environment.GetEnvironmentVariable("AZURE_CLIENT_ID") ?? "";
+        options.ClientSecret = Environment.GetEnvironmentVariable("AZURE_CLIENT_SECRET") ?? "";
+        options.BaseUrl = Environment.GetEnvironmentVariable("DOCX_MCP_BASE_URL") ?? "http://localhost:8080";
+        options.ValidateTokens = Environment.GetEnvironmentVariable("DOCX_MCP_VALIDATE_TOKENS") != "false";
+    });
+
+    builder.Services.Configure<StorageOptions>(options =>
+    {
+        options.Provider = Environment.GetEnvironmentVariable("DOCX_MCP_STORAGE_PROVIDER") ?? "local";
+        options.LocalBasePath = Environment.GetEnvironmentVariable("DOCX_MCP_SESSIONS_DIR") ?? "";
+        options.GcsBucket = Environment.GetEnvironmentVariable("GCS_BUCKET") ?? "";
+        options.GcsPrefix = Environment.GetEnvironmentVariable("GCS_PREFIX") ?? "docx-mcp/sessions/";
+        options.GcsCredentialsPath = Environment.GetEnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS");
+    });
+
+    // Logging
+    builder.Logging.AddConsole();
+
+    // Storage provider (based on configuration)
+    var storageProvider = Environment.GetEnvironmentVariable("DOCX_MCP_STORAGE_PROVIDER")?.ToLowerInvariant() ?? "local";
+    if (storageProvider == "gcs")
+    {
+        builder.Services.AddSingleton<IStorageProvider, GcsStorageProvider>();
+        builder.Services.AddSingleton<CloudSessionStore>();
+    }
+    else
+    {
+        builder.Services.AddSingleton<IStorageProvider, LocalStorageProvider>();
+        builder.Services.AddSingleton<CloudSessionStore>();
+    }
+
+    // Also register the original SessionStore for compatibility
+    builder.Services.AddSingleton<SessionStore>();
+    builder.Services.AddSingleton<SessionManager>();
+    builder.Services.AddHostedService<SessionRestoreService>();
+
+    // HTTP client for OAuth
+    builder.Services.AddHttpClient<TokenService>();
+
+    // SSE Transport
+    builder.Services.AddSingleton<SseTransport>();
+    builder.Services.AddSingleton<McpSseServer>();
+
+    // Authentication
+    var clientId = Environment.GetEnvironmentVariable("AZURE_CLIENT_ID") ?? "";
+    var tenantId = Environment.GetEnvironmentVariable("AZURE_TENANT_ID") ?? "common";
+
+    if (!string.IsNullOrEmpty(clientId))
+    {
+        builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(options =>
+            {
+                options.Authority = $"https://login.microsoftonline.com/{tenantId}/v2.0";
+                options.Audience = clientId;
+                options.TokenValidationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuer = true,
+                    ValidateAudience = true,
+                    ValidateLifetime = true,
+                    ValidAudiences = new[] { clientId, $"api://{clientId}" }
+                };
+
+                // Allow token in query string for SSE connections
+                options.Events = new JwtBearerEvents
+                {
+                    OnMessageReceived = context =>
+                    {
+                        var accessToken = context.Request.Query["access_token"];
+                        var path = context.HttpContext.Request.Path;
+                        if (!string.IsNullOrEmpty(accessToken) && path.StartsWithSegments("/sse"))
+                        {
+                            context.Token = accessToken;
+                        }
+                        return Task.CompletedTask;
+                    }
+                };
+            });
+    }
+    else
+    {
+        // Development mode - no auth required
+        builder.Services.AddAuthentication("Development")
+            .AddScheme<Microsoft.AspNetCore.Authentication.AuthenticationSchemeOptions, DevelopmentAuthHandler>(
+                "Development", null);
+    }
+
+    builder.Services.AddAuthorization();
+
+    // CORS for web clients
+    builder.Services.AddCors(options =>
+    {
+        options.AddDefaultPolicy(policy =>
+        {
+            var allowedOrigins = Environment.GetEnvironmentVariable("DOCX_MCP_CORS_ORIGINS")?.Split(',')
+                ?? new[] { "*" };
+
+            if (allowedOrigins.Contains("*"))
+            {
+                policy.AllowAnyOrigin()
+                      .AllowAnyMethod()
+                      .AllowAnyHeader();
+            }
+            else
+            {
+                policy.WithOrigins(allowedOrigins)
+                      .AllowAnyMethod()
+                      .AllowAnyHeader()
+                      .AllowCredentials();
+            }
+        });
+    });
+
+    var app = builder.Build();
+
+    // Configure pipeline
+    app.UseCors();
+    app.UseAuthentication();
+    app.UseAuthorization();
+
+    // Map MCP endpoints
+    app.MapMcpEndpoints();
+
+    // Get port from environment (Koyeb uses PORT)
+    var port = Environment.GetEnvironmentVariable("PORT") ?? "8080";
+    app.Urls.Add($"http://0.0.0.0:{port}");
+
+    Console.WriteLine($"docx-mcp HTTP/SSE server starting on port {port}");
+    Console.WriteLine($"Storage provider: {storageProvider}");
+    Console.WriteLine($"OAuth: {(string.IsNullOrEmpty(clientId) ? "disabled (development mode)" : "enabled")}");
+
+    await app.RunAsync();
+}
+
+/// <summary>
+/// Development authentication handler - accepts all requests as authenticated.
+/// </summary>
+public class DevelopmentAuthHandler : Microsoft.AspNetCore.Authentication.AuthenticationHandler<Microsoft.AspNetCore.Authentication.AuthenticationSchemeOptions>
+{
+    public DevelopmentAuthHandler(
+        Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.AspNetCore.Authentication.AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        System.Text.Encodings.Web.UrlEncoder encoder)
+        : base(options, logger, encoder)
+    {
+    }
+
+    protected override Task<Microsoft.AspNetCore.Authentication.AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var claims = new[]
+        {
+            new System.Security.Claims.Claim("oid", "dev-user-001"),
+            new System.Security.Claims.Claim("preferred_username", "dev@localhost"),
+            new System.Security.Claims.Claim("name", "Development User"),
+            new System.Security.Claims.Claim("tid", "dev-tenant")
+        };
+
+        var identity = new System.Security.Claims.ClaimsIdentity(claims, "Development");
+        var principal = new System.Security.Claims.ClaimsPrincipal(identity);
+        var ticket = new Microsoft.AspNetCore.Authentication.AuthenticationTicket(principal, "Development");
+
+        return Task.FromResult(Microsoft.AspNetCore.Authentication.AuthenticateResult.Success(ticket));
+    }
+}

--- a/src/DocxMcp/Storage/CloudSessionStore.cs
+++ b/src/DocxMcp/Storage/CloudSessionStore.cs
@@ -1,0 +1,390 @@
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.Json;
+using DocxMcp.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace DocxMcp.Storage;
+
+/// <summary>
+/// Cloud-compatible session store using IStorageProvider.
+/// Replaces memory-mapped files with cloud object storage (GCS, Azure, etc.).
+/// Maintains API compatibility with the original SessionStore.
+/// </summary>
+public sealed class CloudSessionStore : IDisposable
+{
+    private readonly IStorageProvider _storage;
+    private readonly ILogger<CloudSessionStore> _logger;
+    private readonly ConcurrentDictionary<string, CloudWal> _openWals = new();
+    private const string IndexFileName = "index.json";
+
+    public CloudSessionStore(IStorageProvider storage, ILogger<CloudSessionStore> logger)
+    {
+        _storage = storage;
+        _logger = logger;
+    }
+
+    public string ProviderType => _storage.ProviderType;
+
+    public async Task EnsureDirectoryAsync(CancellationToken ct = default)
+    {
+        await _storage.EnsureDirectoryAsync("", ct);
+    }
+
+    // --- Cross-process distributed lock ---
+
+    public async Task<IAsyncDisposable> AcquireLockAsync(TimeSpan? timeout = null, CancellationToken ct = default)
+    {
+        return await _storage.AcquireLockAsync("session-index", timeout ?? TimeSpan.FromSeconds(30), ct);
+    }
+
+    // --- Index operations ---
+
+    public async Task<SessionIndexFile> LoadIndexAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            if (!await _storage.ExistsAsync(IndexFileName, ct))
+                return new SessionIndexFile();
+
+            var bytes = await _storage.ReadAsync(IndexFileName, ct);
+            var json = Encoding.UTF8.GetString(bytes);
+            var index = JsonSerializer.Deserialize(json, SessionJsonContext.Default.SessionIndexFile);
+
+            if (index is null || index.Version != 1)
+                return new SessionIndexFile();
+
+            return index;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to read session index; starting fresh.");
+            return new SessionIndexFile();
+        }
+    }
+
+    public async Task SaveIndexAsync(SessionIndexFile index, CancellationToken ct = default)
+    {
+        var json = JsonSerializer.Serialize(index, SessionJsonContext.Default.SessionIndexFile);
+        var bytes = Encoding.UTF8.GetBytes(json);
+        await _storage.WriteAsync(IndexFileName, bytes, ct);
+    }
+
+    // --- Baseline operations ---
+
+    public async Task PersistBaselineAsync(string sessionId, byte[] bytes, CancellationToken ct = default)
+    {
+        var path = BaselinePath(sessionId);
+        await _storage.WriteAsync(path, bytes, ct);
+    }
+
+    public async Task<byte[]> LoadBaselineAsync(string sessionId, CancellationToken ct = default)
+    {
+        var path = BaselinePath(sessionId);
+        return await _storage.ReadAsync(path, ct);
+    }
+
+    public async Task DeleteSessionAsync(string sessionId, CancellationToken ct = default)
+    {
+        // Close and remove the WAL cache first
+        if (_openWals.TryRemove(sessionId, out var wal))
+            await wal.DisposeAsync();
+
+        await _storage.DeleteAsync(BaselinePath(sessionId), ct);
+        await _storage.DeleteAsync(WalPath(sessionId), ct);
+        await DeleteCheckpointsAsync(sessionId, ct);
+    }
+
+    // --- WAL operations ---
+
+    public async Task<CloudWal> GetOrCreateWalAsync(string sessionId, CancellationToken ct = default)
+    {
+        if (_openWals.TryGetValue(sessionId, out var existing))
+            return existing;
+
+        var wal = new CloudWal(_storage, WalPath(sessionId), _logger);
+        await wal.LoadAsync(ct);
+
+        _openWals[sessionId] = wal;
+        return wal;
+    }
+
+    public async Task AppendWalAsync(string sessionId, string patchesJson, string? description = null, CancellationToken ct = default)
+    {
+        var entry = new WalEntry
+        {
+            Patches = patchesJson,
+            Timestamp = DateTime.UtcNow,
+            Description = description
+        };
+        var line = JsonSerializer.Serialize(entry, WalJsonContext.Default.WalEntry);
+        var wal = await GetOrCreateWalAsync(sessionId, ct);
+        await wal.AppendAsync(line, ct);
+    }
+
+    public async Task<List<string>> ReadWalAsync(string sessionId, CancellationToken ct = default)
+    {
+        var wal = await GetOrCreateWalAsync(sessionId, ct);
+        var patches = new List<string>();
+
+        foreach (var line in wal.ReadAll())
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+            try
+            {
+                var entry = JsonSerializer.Deserialize(line, WalJsonContext.Default.WalEntry);
+                if (entry?.Patches is not null)
+                    patches.Add(entry.Patches);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Skipping corrupt WAL line for session {SessionId}.", sessionId);
+            }
+        }
+
+        return patches;
+    }
+
+    public async Task<List<string>> ReadWalRangeAsync(string sessionId, int from, int to, CancellationToken ct = default)
+    {
+        var wal = await GetOrCreateWalAsync(sessionId, ct);
+        var lines = wal.ReadRange(from, to);
+        var patches = new List<string>(lines.Count);
+
+        foreach (var line in lines)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+            try
+            {
+                var entry = JsonSerializer.Deserialize(line, WalJsonContext.Default.WalEntry);
+                if (entry?.Patches is not null)
+                    patches.Add(entry.Patches);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Skipping corrupt WAL line for session {SessionId}.", sessionId);
+            }
+        }
+
+        return patches;
+    }
+
+    public async Task<List<WalEntry>> ReadWalEntriesAsync(string sessionId, CancellationToken ct = default)
+    {
+        var wal = await GetOrCreateWalAsync(sessionId, ct);
+        var entries = new List<WalEntry>();
+
+        foreach (var line in wal.ReadAll())
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+            try
+            {
+                var entry = JsonSerializer.Deserialize(line, WalJsonContext.Default.WalEntry);
+                if (entry is not null)
+                    entries.Add(entry);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Skipping corrupt WAL entry for session {SessionId}.", sessionId);
+            }
+        }
+
+        return entries;
+    }
+
+    public async Task<int> WalEntryCountAsync(string sessionId, CancellationToken ct = default)
+    {
+        var wal = await GetOrCreateWalAsync(sessionId, ct);
+        return wal.EntryCount;
+    }
+
+    public async Task TruncateWalAsync(string sessionId, CancellationToken ct = default)
+    {
+        var wal = await GetOrCreateWalAsync(sessionId, ct);
+        await wal.TruncateAsync(ct);
+    }
+
+    public async Task TruncateWalAtAsync(string sessionId, int count, CancellationToken ct = default)
+    {
+        var wal = await GetOrCreateWalAsync(sessionId, ct);
+        await wal.TruncateAtAsync(count, ct);
+    }
+
+    // --- Checkpoint operations ---
+
+    public string CheckpointPath(string sessionId, int position) =>
+        $"{sessionId}.ckpt.{position}.docx";
+
+    public async Task PersistCheckpointAsync(string sessionId, int position, byte[] bytes, CancellationToken ct = default)
+    {
+        var path = CheckpointPath(sessionId, position);
+        await _storage.WriteAsync(path, bytes, ct);
+    }
+
+    public async Task<(int position, byte[] bytes)> LoadNearestCheckpointAsync(
+        string sessionId, int targetPosition, List<int> knownPositions, CancellationToken ct = default)
+    {
+        int bestPos = 0;
+        foreach (var pos in knownPositions)
+        {
+            if (pos <= targetPosition && pos > bestPos)
+                bestPos = pos;
+        }
+
+        if (bestPos > 0)
+        {
+            var path = CheckpointPath(sessionId, bestPos);
+            if (await _storage.ExistsAsync(path, ct))
+            {
+                try
+                {
+                    var bytes = await _storage.ReadAsync(path, ct);
+                    return (bestPos, bytes);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to load checkpoint at position {Position} for session {SessionId}; falling back.",
+                        bestPos, sessionId);
+                }
+            }
+        }
+
+        // Fallback to baseline
+        return (0, await LoadBaselineAsync(sessionId, ct));
+    }
+
+    public async Task DeleteCheckpointsAsync(string sessionId, CancellationToken ct = default)
+    {
+        try
+        {
+            var prefix = $"{sessionId}.ckpt.";
+            var files = await _storage.ListAsync(prefix, ct);
+            foreach (var file in files)
+            {
+                await _storage.DeleteAsync(file, ct);
+            }
+        }
+        catch { /* best effort */ }
+    }
+
+    public async Task DeleteCheckpointsAfterAsync(string sessionId, int afterPosition, List<int> knownPositions, CancellationToken ct = default)
+    {
+        foreach (var pos in knownPositions)
+        {
+            if (pos > afterPosition)
+                await _storage.DeleteAsync(CheckpointPath(sessionId, pos), ct);
+        }
+    }
+
+    // --- Path helpers ---
+
+    public static string BaselinePath(string sessionId) => $"{sessionId}.docx";
+    public static string WalPath(string sessionId) => $"{sessionId}.wal";
+
+    public void Dispose()
+    {
+        foreach (var wal in _openWals.Values)
+        {
+            wal.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+        _openWals.Clear();
+    }
+}
+
+/// <summary>
+/// Cloud-based WAL implementation using IStorageProvider.
+/// Caches entries in memory and persists to cloud storage.
+/// </summary>
+public sealed class CloudWal : IAsyncDisposable
+{
+    private readonly IStorageProvider _storage;
+    private readonly string _path;
+    private readonly ILogger _logger;
+    private readonly List<string> _entries = new();
+    private bool _dirty;
+
+    public CloudWal(IStorageProvider storage, string path, ILogger logger)
+    {
+        _storage = storage;
+        _path = path;
+        _logger = logger;
+    }
+
+    public int EntryCount => _entries.Count;
+
+    public async Task LoadAsync(CancellationToken ct = default)
+    {
+        _entries.Clear();
+        try
+        {
+            if (await _storage.ExistsAsync(_path, ct))
+            {
+                var bytes = await _storage.ReadAsync(_path, ct);
+                var content = Encoding.UTF8.GetString(bytes);
+                var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+                _entries.AddRange(lines);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load WAL from {Path}", _path);
+        }
+        _dirty = false;
+    }
+
+    public async Task AppendAsync(string line, CancellationToken ct = default)
+    {
+        _entries.Add(line);
+        _dirty = true;
+        await PersistAsync(ct);
+    }
+
+    public List<string> ReadAll() => _entries.ToList();
+
+    public List<string> ReadRange(int from, int to)
+    {
+        var actualTo = Math.Min(to, _entries.Count);
+        var actualFrom = Math.Max(from, 0);
+        if (actualFrom >= actualTo)
+            return new List<string>();
+        return _entries.GetRange(actualFrom, actualTo - actualFrom);
+    }
+
+    public async Task TruncateAsync(CancellationToken ct = default)
+    {
+        _entries.Clear();
+        _dirty = true;
+        await PersistAsync(ct);
+    }
+
+    public async Task TruncateAtAsync(int count, CancellationToken ct = default)
+    {
+        if (count < _entries.Count)
+        {
+            _entries.RemoveRange(count, _entries.Count - count);
+            _dirty = true;
+            await PersistAsync(ct);
+        }
+    }
+
+    private async Task PersistAsync(CancellationToken ct = default)
+    {
+        if (!_dirty) return;
+
+        var content = string.Join("\n", _entries);
+        var bytes = Encoding.UTF8.GetBytes(content);
+        await _storage.WriteAsync(_path, bytes, ct);
+        _dirty = false;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_dirty)
+        {
+            await PersistAsync();
+        }
+    }
+}

--- a/src/DocxMcp/Storage/GcsStorageProvider.cs
+++ b/src/DocxMcp/Storage/GcsStorageProvider.cs
@@ -1,0 +1,234 @@
+using System.Text;
+using Google.Apis.Auth.OAuth2;
+using Google.Cloud.Storage.V1;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace DocxMcp.Storage;
+
+/// <summary>
+/// Google Cloud Storage provider for session persistence.
+/// Supports workload identity, service account, and ADC authentication.
+/// </summary>
+public sealed class GcsStorageProvider : IStorageProvider
+{
+    private readonly StorageClient _client;
+    private readonly string _bucket;
+    private readonly string _prefix;
+    private readonly ILogger<GcsStorageProvider> _logger;
+
+    public string ProviderType => "gcs";
+
+    public GcsStorageProvider(IOptions<StorageOptions> options, ILogger<GcsStorageProvider> logger)
+    {
+        var opts = options.Value;
+        _bucket = opts.GcsBucket;
+        _prefix = opts.GcsPrefix.TrimEnd('/') + "/";
+        _logger = logger;
+
+        if (string.IsNullOrEmpty(_bucket))
+            throw new ArgumentException("GCS bucket name is required");
+
+        // Create client with credentials
+        if (!string.IsNullOrEmpty(opts.GcsCredentialsPath) && File.Exists(opts.GcsCredentialsPath))
+        {
+            var credential = GoogleCredential.FromFile(opts.GcsCredentialsPath);
+            _client = StorageClient.Create(credential);
+            _logger.LogInformation("GCS client created with service account from file");
+        }
+        else
+        {
+            // Use Application Default Credentials (ADC) - workload identity, env var, etc.
+            _client = StorageClient.Create();
+            _logger.LogInformation("GCS client created with Application Default Credentials");
+        }
+    }
+
+    public async Task<byte[]> ReadAsync(string path, CancellationToken ct = default)
+    {
+        var objectName = GetObjectName(path);
+        using var ms = new MemoryStream();
+        await _client.DownloadObjectAsync(_bucket, objectName, ms, cancellationToken: ct);
+        return ms.ToArray();
+    }
+
+    public async Task WriteAsync(string path, byte[] data, CancellationToken ct = default)
+    {
+        var objectName = GetObjectName(path);
+        using var ms = new MemoryStream(data);
+        await _client.UploadObjectAsync(_bucket, objectName, "application/octet-stream", ms, cancellationToken: ct);
+    }
+
+    public async Task WriteAsync(string path, Stream data, CancellationToken ct = default)
+    {
+        var objectName = GetObjectName(path);
+        await _client.UploadObjectAsync(_bucket, objectName, "application/octet-stream", data, cancellationToken: ct);
+    }
+
+    public async Task DeleteAsync(string path, CancellationToken ct = default)
+    {
+        var objectName = GetObjectName(path);
+        try
+        {
+            await _client.DeleteObjectAsync(_bucket, objectName, cancellationToken: ct);
+        }
+        catch (Google.GoogleApiException ex) when (ex.HttpStatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            // Object doesn't exist, that's fine
+        }
+    }
+
+    public async Task<bool> ExistsAsync(string path, CancellationToken ct = default)
+    {
+        var objectName = GetObjectName(path);
+        try
+        {
+            await _client.GetObjectAsync(_bucket, objectName, cancellationToken: ct);
+            return true;
+        }
+        catch (Google.GoogleApiException ex) when (ex.HttpStatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return false;
+        }
+    }
+
+    public async Task<IReadOnlyList<string>> ListAsync(string prefix, CancellationToken ct = default)
+    {
+        var fullPrefix = GetObjectName(prefix);
+        var objects = new List<string>();
+
+        var request = _client.ListObjectsAsync(_bucket, fullPrefix);
+        await foreach (var obj in request.WithCancellation(ct))
+        {
+            // Return path without the base prefix
+            var relativePath = obj.Name.StartsWith(_prefix)
+                ? obj.Name[_prefix.Length..]
+                : obj.Name;
+            objects.Add(relativePath);
+        }
+
+        return objects;
+    }
+
+    public Task EnsureDirectoryAsync(string path, CancellationToken ct = default)
+    {
+        // GCS doesn't have real directories, no-op
+        return Task.CompletedTask;
+    }
+
+    public async Task<IAsyncDisposable> AcquireLockAsync(string key, TimeSpan timeout, CancellationToken ct = default)
+    {
+        var lockPath = $".locks/{key}.lock";
+        var gcsLock = new GcsDistributedLock(_client, _bucket, GetObjectName(lockPath), timeout, _logger);
+        await gcsLock.AcquireAsync(ct);
+        return gcsLock;
+    }
+
+    private string GetObjectName(string relativePath)
+    {
+        var normalized = relativePath.Replace('\\', '/').TrimStart('/');
+        if (normalized.Contains(".."))
+            throw new ArgumentException("Path traversal not allowed");
+        return _prefix + normalized;
+    }
+}
+
+/// <summary>
+/// GCS-based distributed lock using generation-based optimistic locking.
+/// </summary>
+internal sealed class GcsDistributedLock : IAsyncDisposable
+{
+    private readonly StorageClient _client;
+    private readonly string _bucket;
+    private readonly string _objectName;
+    private readonly TimeSpan _timeout;
+    private readonly ILogger _logger;
+    private readonly string _lockId;
+    private bool _acquired;
+
+    public GcsDistributedLock(StorageClient client, string bucket, string objectName, TimeSpan timeout, ILogger logger)
+    {
+        _client = client;
+        _bucket = bucket;
+        _objectName = objectName;
+        _timeout = timeout;
+        _logger = logger;
+        _lockId = Guid.NewGuid().ToString("N");
+    }
+
+    public async Task AcquireAsync(CancellationToken ct)
+    {
+        var deadline = DateTime.UtcNow + _timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                // Try to create the lock object (fails if exists)
+                var lockContent = Encoding.UTF8.GetBytes($"{_lockId}|{DateTime.UtcNow:O}");
+                using var ms = new MemoryStream(lockContent);
+
+                await _client.UploadObjectAsync(
+                    _bucket,
+                    _objectName,
+                    "text/plain",
+                    ms,
+                    new UploadObjectOptions { IfGenerationMatch = 0 }, // Only if doesn't exist
+                    ct);
+
+                _acquired = true;
+                _logger.LogDebug("Acquired GCS lock: {ObjectName}", _objectName);
+                return;
+            }
+            catch (Google.GoogleApiException ex) when (ex.HttpStatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+            {
+                // Lock exists, check if it's stale
+                try
+                {
+                    var obj = await _client.GetObjectAsync(_bucket, _objectName, cancellationToken: ct);
+                    using var ms = new MemoryStream();
+                    await _client.DownloadObjectAsync(_bucket, _objectName, ms, cancellationToken: ct);
+                    var content = Encoding.UTF8.GetString(ms.ToArray());
+                    var parts = content.Split('|');
+
+                    if (parts.Length >= 2 && DateTime.TryParse(parts[1], out var lockTime))
+                    {
+                        // Consider locks older than 5 minutes as stale
+                        if (DateTime.UtcNow - lockTime > TimeSpan.FromMinutes(5))
+                        {
+                            _logger.LogWarning("Found stale lock, attempting to take over: {ObjectName}", _objectName);
+                            await _client.DeleteObjectAsync(_bucket, _objectName,
+                                new DeleteObjectOptions { IfGenerationMatch = obj.Generation },
+                                ct);
+                            continue; // Retry acquiring
+                        }
+                    }
+                }
+                catch
+                {
+                    // Ignore errors checking stale lock
+                }
+
+                await Task.Delay(100, ct);
+            }
+        }
+
+        throw new TimeoutException($"Failed to acquire GCS lock: {_objectName}");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_acquired)
+        {
+            try
+            {
+                await _client.DeleteObjectAsync(_bucket, _objectName);
+                _logger.LogDebug("Released GCS lock: {ObjectName}", _objectName);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to release GCS lock: {ObjectName}", _objectName);
+            }
+        }
+    }
+}

--- a/src/DocxMcp/Storage/IStorageProvider.cs
+++ b/src/DocxMcp/Storage/IStorageProvider.cs
@@ -1,0 +1,97 @@
+namespace DocxMcp.Storage;
+
+/// <summary>
+/// Abstract storage provider interface for session persistence.
+/// Implementations support local filesystem, GCS, Azure Blob, etc.
+/// </summary>
+public interface IStorageProvider
+{
+    /// <summary>
+    /// Read a file as bytes.
+    /// </summary>
+    Task<byte[]> ReadAsync(string path, CancellationToken ct = default);
+
+    /// <summary>
+    /// Write bytes to a file, creating or overwriting.
+    /// </summary>
+    Task WriteAsync(string path, byte[] data, CancellationToken ct = default);
+
+    /// <summary>
+    /// Write a stream to a file, creating or overwriting.
+    /// </summary>
+    Task WriteAsync(string path, Stream data, CancellationToken ct = default);
+
+    /// <summary>
+    /// Delete a file.
+    /// </summary>
+    Task DeleteAsync(string path, CancellationToken ct = default);
+
+    /// <summary>
+    /// Check if a file exists.
+    /// </summary>
+    Task<bool> ExistsAsync(string path, CancellationToken ct = default);
+
+    /// <summary>
+    /// List files matching a prefix/pattern.
+    /// </summary>
+    Task<IReadOnlyList<string>> ListAsync(string prefix, CancellationToken ct = default);
+
+    /// <summary>
+    /// Create a directory (no-op for object storage).
+    /// </summary>
+    Task EnsureDirectoryAsync(string path, CancellationToken ct = default);
+
+    /// <summary>
+    /// Acquire a distributed lock for the given key.
+    /// Returns a disposable that releases the lock when disposed.
+    /// </summary>
+    Task<IAsyncDisposable> AcquireLockAsync(string key, TimeSpan timeout, CancellationToken ct = default);
+
+    /// <summary>
+    /// Provider type identifier.
+    /// </summary>
+    string ProviderType { get; }
+}
+
+/// <summary>
+/// Storage provider options.
+/// </summary>
+public sealed class StorageOptions
+{
+    public const string SectionName = "Storage";
+
+    /// <summary>
+    /// Provider type: "local", "gcs", "azure".
+    /// </summary>
+    public string Provider { get; set; } = "local";
+
+    /// <summary>
+    /// Base path for local storage.
+    /// </summary>
+    public string LocalBasePath { get; set; } = "";
+
+    /// <summary>
+    /// GCS bucket name.
+    /// </summary>
+    public string GcsBucket { get; set; } = "";
+
+    /// <summary>
+    /// GCS base prefix for objects.
+    /// </summary>
+    public string GcsPrefix { get; set; } = "docx-mcp/sessions/";
+
+    /// <summary>
+    /// Path to GCS credentials JSON file (optional if using workload identity).
+    /// </summary>
+    public string? GcsCredentialsPath { get; set; }
+
+    /// <summary>
+    /// Azure Blob container name.
+    /// </summary>
+    public string AzureContainer { get; set; } = "";
+
+    /// <summary>
+    /// Azure Storage connection string.
+    /// </summary>
+    public string? AzureConnectionString { get; set; }
+}

--- a/src/DocxMcp/Storage/LocalStorageProvider.cs
+++ b/src/DocxMcp/Storage/LocalStorageProvider.cs
@@ -1,0 +1,155 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace DocxMcp.Storage;
+
+/// <summary>
+/// Local filesystem storage provider.
+/// Used for development and Docker deployments with mounted volumes.
+/// </summary>
+public sealed class LocalStorageProvider : IStorageProvider
+{
+    private readonly string _basePath;
+    private readonly ILogger<LocalStorageProvider> _logger;
+
+    public string ProviderType => "local";
+
+    public LocalStorageProvider(IOptions<StorageOptions> options, ILogger<LocalStorageProvider> logger)
+    {
+        _basePath = !string.IsNullOrEmpty(options.Value.LocalBasePath)
+            ? options.Value.LocalBasePath
+            : Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".docx-mcp", "sessions");
+        _logger = logger;
+
+        Directory.CreateDirectory(_basePath);
+    }
+
+    public Task<byte[]> ReadAsync(string path, CancellationToken ct = default)
+    {
+        var fullPath = GetFullPath(path);
+        return File.ReadAllBytesAsync(fullPath, ct);
+    }
+
+    public Task WriteAsync(string path, byte[] data, CancellationToken ct = default)
+    {
+        var fullPath = GetFullPath(path);
+        var dir = Path.GetDirectoryName(fullPath);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+
+        return File.WriteAllBytesAsync(fullPath, data, ct);
+    }
+
+    public async Task WriteAsync(string path, Stream data, CancellationToken ct = default)
+    {
+        var fullPath = GetFullPath(path);
+        var dir = Path.GetDirectoryName(fullPath);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+
+        await using var fs = File.Create(fullPath);
+        await data.CopyToAsync(fs, ct);
+    }
+
+    public Task DeleteAsync(string path, CancellationToken ct = default)
+    {
+        var fullPath = GetFullPath(path);
+        if (File.Exists(fullPath))
+            File.Delete(fullPath);
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> ExistsAsync(string path, CancellationToken ct = default)
+    {
+        var fullPath = GetFullPath(path);
+        return Task.FromResult(File.Exists(fullPath));
+    }
+
+    public Task<IReadOnlyList<string>> ListAsync(string prefix, CancellationToken ct = default)
+    {
+        var fullPrefix = GetFullPath(prefix);
+        var dir = Path.GetDirectoryName(fullPrefix) ?? _basePath;
+        var pattern = Path.GetFileName(fullPrefix) + "*";
+
+        if (!Directory.Exists(dir))
+            return Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
+
+        var files = Directory.GetFiles(dir, pattern)
+            .Select(f => Path.GetRelativePath(_basePath, f).Replace('\\', '/'))
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<string>>(files);
+    }
+
+    public Task EnsureDirectoryAsync(string path, CancellationToken ct = default)
+    {
+        var fullPath = GetFullPath(path);
+        Directory.CreateDirectory(fullPath);
+        return Task.CompletedTask;
+    }
+
+    public Task<IAsyncDisposable> AcquireLockAsync(string key, TimeSpan timeout, CancellationToken ct = default)
+    {
+        var lockPath = GetFullPath($".locks/{key}.lock");
+        var lockDir = Path.GetDirectoryName(lockPath)!;
+        Directory.CreateDirectory(lockDir);
+
+        var lockFile = new LocalFileLock(lockPath, timeout, _logger);
+        return Task.FromResult<IAsyncDisposable>(lockFile);
+    }
+
+    private string GetFullPath(string relativePath)
+    {
+        // Normalize and prevent path traversal
+        var normalized = relativePath.Replace('\\', '/').TrimStart('/');
+        if (normalized.Contains(".."))
+            throw new ArgumentException("Path traversal not allowed");
+
+        return Path.Combine(_basePath, normalized);
+    }
+}
+
+/// <summary>
+/// File-based lock for local storage.
+/// </summary>
+internal sealed class LocalFileLock : IAsyncDisposable
+{
+    private readonly string _path;
+    private FileStream? _stream;
+    private readonly ILogger _logger;
+
+    public LocalFileLock(string path, TimeSpan timeout, ILogger logger)
+    {
+        _path = path;
+        _logger = logger;
+
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                _stream = new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+                return;
+            }
+            catch (IOException)
+            {
+                Thread.Sleep(50);
+            }
+        }
+
+        throw new TimeoutException($"Failed to acquire lock: {path}");
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        if (_stream is not null)
+        {
+            _stream.Dispose();
+            try { File.Delete(_path); } catch { }
+            _stream = null;
+        }
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/DocxMcp/Transport/McpSseServer.cs
+++ b/src/DocxMcp/Transport/McpSseServer.cs
@@ -1,0 +1,343 @@
+using System.Text.Json;
+using DocxMcp.Auth;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Protocol.Messages;
+using ModelContextProtocol.Protocol.Types;
+using ModelContextProtocol.Server;
+
+namespace DocxMcp.Transport;
+
+/// <summary>
+/// MCP server implementation that works over SSE transport.
+/// Bridges the SSE connection with the MCP protocol handlers.
+/// </summary>
+public sealed class McpSseServer
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<McpSseServer> _logger;
+    private readonly SseTransport _transport;
+    private readonly Dictionary<string, Func<JsonElement, UserContext, CancellationToken, Task<object?>>> _methodHandlers = new();
+
+    public McpSseServer(
+        IServiceProvider serviceProvider,
+        SseTransport transport,
+        ILogger<McpSseServer> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _transport = transport;
+        _logger = logger;
+
+        RegisterHandlers();
+    }
+
+    private void RegisterHandlers()
+    {
+        _methodHandlers["initialize"] = HandleInitializeAsync;
+        _methodHandlers["initialized"] = HandleInitializedAsync;
+        _methodHandlers["tools/list"] = HandleToolsListAsync;
+        _methodHandlers["tools/call"] = HandleToolCallAsync;
+        _methodHandlers["ping"] = HandlePingAsync;
+    }
+
+    /// <summary>
+    /// Process an incoming JSON-RPC message from a client.
+    /// </summary>
+    public async Task<JsonDocument?> ProcessMessageAsync(
+        SseConnection connection,
+        JsonDocument message,
+        CancellationToken ct)
+    {
+        try
+        {
+            var root = message.RootElement;
+
+            // Check if it's a request or notification
+            var hasId = root.TryGetProperty("id", out var idElement);
+            var method = root.TryGetProperty("method", out var methodElement)
+                ? methodElement.GetString()
+                : null;
+
+            if (string.IsNullOrEmpty(method))
+            {
+                _logger.LogWarning("Received message without method");
+                return CreateErrorResponse(idElement, -32600, "Invalid Request: missing method");
+            }
+
+            _logger.LogDebug("Processing MCP method: {Method} for connection {ConnectionId}", method, connection.ConnectionId);
+
+            // Get params
+            var paramsElement = root.TryGetProperty("params", out var p) ? p : default;
+
+            // Find handler
+            if (!_methodHandlers.TryGetValue(method, out var handler))
+            {
+                _logger.LogWarning("Unknown method: {Method}", method);
+                return CreateErrorResponse(idElement, -32601, $"Method not found: {method}");
+            }
+
+            // Execute handler
+            var result = await handler(paramsElement, connection.User, ct);
+
+            // If it's a notification (no id), don't send response
+            if (!hasId)
+                return null;
+
+            // Build response
+            return CreateSuccessResponse(idElement, result);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error processing MCP message");
+            return CreateErrorResponse(default, -32603, $"Internal error: {ex.Message}");
+        }
+    }
+
+    private Task<object?> HandleInitializeAsync(JsonElement paramsEl, UserContext user, CancellationToken ct)
+    {
+        var result = new InitializeResult
+        {
+            ProtocolVersion = "2024-11-05",
+            ServerInfo = new Implementation
+            {
+                Name = "docx-mcp",
+                Version = "2.1.0"
+            },
+            Capabilities = new ServerCapabilities
+            {
+                Tools = new ToolsCapability
+                {
+                    ListChanged = false
+                }
+            }
+        };
+
+        return Task.FromResult<object?>(result);
+    }
+
+    private Task<object?> HandleInitializedAsync(JsonElement paramsEl, UserContext user, CancellationToken ct)
+    {
+        // Notification - no response needed
+        return Task.FromResult<object?>(null);
+    }
+
+    private async Task<object?> HandleToolsListAsync(JsonElement paramsEl, UserContext user, CancellationToken ct)
+    {
+        // Get tools from the registered tool types
+        var tools = GetRegisteredTools();
+
+        return await Task.FromResult<object?>(new { tools });
+    }
+
+    private async Task<object?> HandleToolCallAsync(JsonElement paramsEl, UserContext user, CancellationToken ct)
+    {
+        var toolName = paramsEl.TryGetProperty("name", out var nameEl) ? nameEl.GetString() : null;
+        var arguments = paramsEl.TryGetProperty("arguments", out var argsEl) ? argsEl : default;
+
+        if (string.IsNullOrEmpty(toolName))
+        {
+            throw new InvalidOperationException("Tool name is required");
+        }
+
+        _logger.LogInformation("Calling tool: {ToolName} for user {UserId}", toolName, user.UserId);
+
+        // Execute the tool using the service provider
+        var result = await ExecuteToolAsync(toolName, arguments, user, ct);
+
+        return new
+        {
+            content = new[]
+            {
+                new { type = "text", text = result }
+            }
+        };
+    }
+
+    private Task<object?> HandlePingAsync(JsonElement paramsEl, UserContext user, CancellationToken ct)
+    {
+        return Task.FromResult<object?>(new { });
+    }
+
+    private async Task<string> ExecuteToolAsync(string toolName, JsonElement arguments, UserContext user, CancellationToken ct)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var sessionManager = scope.ServiceProvider.GetRequiredService<SessionManager>();
+
+        // Map tool names to handlers
+        // This is a simplified version - in production, use reflection or a registry
+        return toolName switch
+        {
+            "document_open" => ExecuteDocumentOpen(sessionManager, arguments, user),
+            "document_create" => ExecuteDocumentCreate(sessionManager),
+            "document_save" => ExecuteDocumentSave(sessionManager, arguments),
+            "document_close" => ExecuteDocumentClose(sessionManager, arguments),
+            "document_list" => ExecuteDocumentList(sessionManager),
+            "query" => await ExecuteQueryAsync(sessionManager, arguments, ct),
+            "count_elements" => ExecuteCountElements(sessionManager, arguments),
+            "apply_patch" => ExecuteApplyPatch(sessionManager, arguments),
+            "document_undo" => ExecuteUndo(sessionManager, arguments),
+            "document_redo" => ExecuteRedo(sessionManager, arguments),
+            "document_history" => ExecuteHistory(sessionManager, arguments),
+            "document_jump_to" => ExecuteJumpTo(sessionManager, arguments),
+            _ => throw new InvalidOperationException($"Unknown tool: {toolName}")
+        };
+    }
+
+    private string ExecuteDocumentOpen(SessionManager sessionManager, JsonElement args, UserContext user)
+    {
+        var path = args.TryGetProperty("path", out var pathEl) ? pathEl.GetString() : null;
+
+        if (string.IsNullOrEmpty(path))
+        {
+            var session = sessionManager.Create();
+            return JsonSerializer.Serialize(new { session_id = session.Id, message = "Created new empty document" });
+        }
+
+        // For cloud storage, we'll need to fetch the document first
+        // This is a placeholder - actual implementation will use IDocumentProvider
+        var openedSession = sessionManager.Open(path);
+        return JsonSerializer.Serialize(new { session_id = openedSession.Id, source_path = path });
+    }
+
+    private string ExecuteDocumentCreate(SessionManager sessionManager)
+    {
+        var session = sessionManager.Create();
+        return JsonSerializer.Serialize(new { session_id = session.Id, message = "Created new empty document" });
+    }
+
+    private string ExecuteDocumentSave(SessionManager sessionManager, JsonElement args)
+    {
+        var sessionId = args.GetProperty("session_id").GetString()!;
+        var path = args.TryGetProperty("path", out var pathEl) ? pathEl.GetString() : null;
+        sessionManager.Save(sessionId, path);
+        return JsonSerializer.Serialize(new { success = true, message = $"Document saved{(path != null ? $" to {path}" : "")}" });
+    }
+
+    private string ExecuteDocumentClose(SessionManager sessionManager, JsonElement args)
+    {
+        var sessionId = args.GetProperty("session_id").GetString()!;
+        sessionManager.Close(sessionId);
+        return JsonSerializer.Serialize(new { success = true, message = "Document closed" });
+    }
+
+    private string ExecuteDocumentList(SessionManager sessionManager)
+    {
+        var sessions = sessionManager.List();
+        return JsonSerializer.Serialize(new
+        {
+            sessions = sessions.Select(s => new { id = s.Id, path = s.Path })
+        });
+    }
+
+    private Task<string> ExecuteQueryAsync(SessionManager sessionManager, JsonElement args, CancellationToken ct)
+    {
+        var sessionId = args.GetProperty("session_id").GetString()!;
+        var path = args.GetProperty("path").GetString()!;
+        var format = args.TryGetProperty("format", out var fEl) ? fEl.GetString() : "json";
+        var offset = args.TryGetProperty("offset", out var oEl) ? oEl.GetInt32() : (int?)null;
+        var limit = args.TryGetProperty("limit", out var lEl) ? lEl.GetInt32() : (int?)null;
+
+        // Call the existing tool method directly
+        var result = Tools.QueryTool.Query(sessionManager, sessionId, path, format, offset, limit);
+        return Task.FromResult(result);
+    }
+
+    private string ExecuteCountElements(SessionManager sessionManager, JsonElement args)
+    {
+        var sessionId = args.GetProperty("session_id").GetString()!;
+        var path = args.GetProperty("path").GetString()!;
+
+        // Call the existing tool method directly
+        return Tools.CountTool.CountElements(sessionManager, sessionId, path);
+    }
+
+    private string ExecuteApplyPatch(SessionManager sessionManager, JsonElement args)
+    {
+        var sessionId = args.GetProperty("session_id").GetString()!;
+        var patches = args.GetProperty("patches").GetRawText();
+
+        // Call the existing tool method directly
+        return Tools.PatchTool.ApplyPatch(sessionManager, sessionId, patches);
+    }
+
+    private string ExecuteUndo(SessionManager sessionManager, JsonElement args)
+    {
+        var sessionId = args.GetProperty("session_id").GetString()!;
+        var steps = args.TryGetProperty("steps", out var stepsEl) ? stepsEl.GetInt32() : 1;
+
+        var result = sessionManager.Undo(sessionId, steps);
+        return JsonSerializer.Serialize(result);
+    }
+
+    private string ExecuteRedo(SessionManager sessionManager, JsonElement args)
+    {
+        var sessionId = args.GetProperty("session_id").GetString()!;
+        var steps = args.TryGetProperty("steps", out var stepsEl) ? stepsEl.GetInt32() : 1;
+
+        var result = sessionManager.Redo(sessionId, steps);
+        return JsonSerializer.Serialize(result);
+    }
+
+    private string ExecuteHistory(SessionManager sessionManager, JsonElement args)
+    {
+        var sessionId = args.GetProperty("session_id").GetString()!;
+        var offset = args.TryGetProperty("offset", out var oEl) ? oEl.GetInt32() : 0;
+        var limit = args.TryGetProperty("limit", out var lEl) ? lEl.GetInt32() : 20;
+
+        var result = sessionManager.GetHistory(sessionId, offset, limit);
+        return JsonSerializer.Serialize(result);
+    }
+
+    private string ExecuteJumpTo(SessionManager sessionManager, JsonElement args)
+    {
+        var sessionId = args.GetProperty("session_id").GetString()!;
+        var position = args.GetProperty("position").GetInt32();
+
+        var result = sessionManager.JumpTo(sessionId, position);
+        return JsonSerializer.Serialize(result);
+    }
+
+    private static List<object> GetRegisteredTools()
+    {
+        // Return tool definitions - this should ideally be built from reflection
+        return new List<object>
+        {
+            new { name = "document_open", description = "Open a DOCX document or create a new one", inputSchema = new { type = "object", properties = new { path = new { type = "string", description = "Path to DOCX file (optional)" } } } },
+            new { name = "document_create", description = "Create a new empty DOCX document", inputSchema = new { type = "object", properties = new { } } },
+            new { name = "document_save", description = "Save a document", inputSchema = new { type = "object", properties = new { session_id = new { type = "string" }, path = new { type = "string" } }, required = new[] { "session_id" } } },
+            new { name = "document_close", description = "Close a document session", inputSchema = new { type = "object", properties = new { session_id = new { type = "string" } }, required = new[] { "session_id" } } },
+            new { name = "document_list", description = "List all open document sessions", inputSchema = new { type = "object", properties = new { } } },
+            new { name = "query", description = "Query document elements using typed paths", inputSchema = new { type = "object", properties = new { session_id = new { type = "string" }, path = new { type = "string" }, offset = new { type = "integer" }, limit = new { type = "integer" } }, required = new[] { "session_id", "path" } } },
+            new { name = "count_elements", description = "Count elements matching a path", inputSchema = new { type = "object", properties = new { session_id = new { type = "string" }, path = new { type = "string" } }, required = new[] { "session_id", "path" } } },
+            new { name = "apply_patch", description = "Apply JSON patches to the document", inputSchema = new { type = "object", properties = new { session_id = new { type = "string" }, patches = new { type = "array" } }, required = new[] { "session_id", "patches" } } },
+            new { name = "document_undo", description = "Undo recent changes", inputSchema = new { type = "object", properties = new { session_id = new { type = "string" }, steps = new { type = "integer" } }, required = new[] { "session_id" } } },
+            new { name = "document_redo", description = "Redo undone changes", inputSchema = new { type = "object", properties = new { session_id = new { type = "string" }, steps = new { type = "integer" } }, required = new[] { "session_id" } } },
+            new { name = "document_history", description = "Get edit history", inputSchema = new { type = "object", properties = new { session_id = new { type = "string" }, offset = new { type = "integer" }, limit = new { type = "integer" } }, required = new[] { "session_id" } } },
+            new { name = "document_jump_to", description = "Jump to a specific history position", inputSchema = new { type = "object", properties = new { session_id = new { type = "string" }, position = new { type = "integer" } }, required = new[] { "session_id", "position" } } }
+        };
+    }
+
+    private static JsonDocument CreateSuccessResponse(JsonElement id, object? result)
+    {
+        var response = new
+        {
+            jsonrpc = "2.0",
+            id = id.ValueKind != JsonValueKind.Undefined ? id.Clone() : null,
+            result
+        };
+        var json = JsonSerializer.Serialize(response);
+        return JsonDocument.Parse(json);
+    }
+
+    private static JsonDocument CreateErrorResponse(JsonElement id, int code, string message)
+    {
+        var response = new
+        {
+            jsonrpc = "2.0",
+            id = id.ValueKind != JsonValueKind.Undefined ? (object?)id.Clone() : null,
+            error = new { code, message }
+        };
+        var json = JsonSerializer.Serialize(response);
+        return JsonDocument.Parse(json);
+    }
+}

--- a/src/DocxMcp/Transport/SseTransport.cs
+++ b/src/DocxMcp/Transport/SseTransport.cs
@@ -1,0 +1,239 @@
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Channels;
+using DocxMcp.Auth;
+using Microsoft.Extensions.Logging;
+
+namespace DocxMcp.Transport;
+
+/// <summary>
+/// MCP transport implementation using Server-Sent Events (SSE).
+/// Handles bidirectional communication: SSE for server→client, HTTP POST for client→server.
+/// </summary>
+public sealed class SseTransport : IAsyncDisposable
+{
+    private readonly ILogger<SseTransport> _logger;
+    private readonly ConcurrentDictionary<string, SseConnection> _connections = new();
+
+    public SseTransport(ILogger<SseTransport> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Create a new SSE connection for a user.
+    /// </summary>
+    public SseConnection CreateConnection(string connectionId, UserContext user)
+    {
+        var connection = new SseConnection(connectionId, user, _logger);
+        _connections[connectionId] = connection;
+        _logger.LogInformation("SSE connection created: {ConnectionId} for user {UserId}", connectionId, user.UserId);
+        return connection;
+    }
+
+    /// <summary>
+    /// Get an existing connection by ID.
+    /// </summary>
+    public SseConnection? GetConnection(string connectionId)
+    {
+        return _connections.TryGetValue(connectionId, out var connection) ? connection : null;
+    }
+
+    /// <summary>
+    /// Remove a connection.
+    /// </summary>
+    public async Task RemoveConnectionAsync(string connectionId)
+    {
+        if (_connections.TryRemove(connectionId, out var connection))
+        {
+            await connection.DisposeAsync();
+            _logger.LogInformation("SSE connection removed: {ConnectionId}", connectionId);
+        }
+    }
+
+    /// <summary>
+    /// Get all active connections.
+    /// </summary>
+    public IEnumerable<SseConnection> GetAllConnections() => _connections.Values;
+
+    /// <summary>
+    /// Get connections for a specific user.
+    /// </summary>
+    public IEnumerable<SseConnection> GetConnectionsForUser(string userId)
+    {
+        return _connections.Values.Where(c => c.User.UserId == userId);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var connection in _connections.Values)
+        {
+            await connection.DisposeAsync();
+        }
+        _connections.Clear();
+    }
+}
+
+/// <summary>
+/// Represents a single SSE connection to a client.
+/// </summary>
+public sealed class SseConnection : IAsyncDisposable
+{
+    private readonly Channel<SseMessage> _outboundChannel;
+    private readonly Channel<JsonDocument> _inboundChannel;
+    private readonly ILogger _logger;
+    private readonly CancellationTokenSource _cts = new();
+    private bool _disposed;
+
+    public string ConnectionId { get; }
+    public UserContext User { get; }
+    public DateTime ConnectedAt { get; } = DateTime.UtcNow;
+    public DateTime LastActivityAt { get; private set; } = DateTime.UtcNow;
+
+    public SseConnection(string connectionId, UserContext user, ILogger logger)
+    {
+        ConnectionId = connectionId;
+        User = user;
+        _logger = logger;
+        _outboundChannel = Channel.CreateBounded<SseMessage>(new BoundedChannelOptions(100)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest
+        });
+        _inboundChannel = Channel.CreateBounded<JsonDocument>(new BoundedChannelOptions(100)
+        {
+            FullMode = BoundedChannelFullMode.Wait
+        });
+    }
+
+    /// <summary>
+    /// Send a message to the client via SSE.
+    /// </summary>
+    public async ValueTask SendAsync(string eventType, object data, CancellationToken ct = default)
+    {
+        if (_disposed) return;
+
+        var message = new SseMessage
+        {
+            Event = eventType,
+            Data = JsonSerializer.Serialize(data),
+            Id = Guid.NewGuid().ToString("N")[..8]
+        };
+
+        await _outboundChannel.Writer.WriteAsync(message, ct);
+        LastActivityAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Send a raw JSON-RPC message.
+    /// </summary>
+    public async ValueTask SendJsonRpcAsync(JsonDocument message, CancellationToken ct = default)
+    {
+        if (_disposed) return;
+
+        var sseMessage = new SseMessage
+        {
+            Event = "message",
+            Data = message.RootElement.GetRawText(),
+            Id = Guid.NewGuid().ToString("N")[..8]
+        };
+
+        await _outboundChannel.Writer.WriteAsync(sseMessage, ct);
+        LastActivityAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Receive a message from the client (via HTTP POST).
+    /// </summary>
+    public async ValueTask ReceiveAsync(JsonDocument message, CancellationToken ct = default)
+    {
+        if (_disposed) return;
+
+        await _inboundChannel.Writer.WriteAsync(message, ct);
+        LastActivityAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Read inbound messages (for MCP server processing).
+    /// </summary>
+    public IAsyncEnumerable<JsonDocument> ReadInboundAsync(CancellationToken ct = default)
+    {
+        return _inboundChannel.Reader.ReadAllAsync(ct);
+    }
+
+    /// <summary>
+    /// Stream SSE messages to the HTTP response.
+    /// </summary>
+    public async Task StreamToResponseAsync(Stream responseStream, CancellationToken ct)
+    {
+        var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, _cts.Token);
+        var writer = new StreamWriter(responseStream, Encoding.UTF8, leaveOpen: true)
+        {
+            AutoFlush = true
+        };
+
+        try
+        {
+            // Send initial connection event
+            await WriteEventAsync(writer, new SseMessage
+            {
+                Event = "connected",
+                Data = JsonSerializer.Serialize(new { connectionId = ConnectionId }),
+                Id = "0"
+            });
+
+            // Stream messages
+            await foreach (var message in _outboundChannel.Reader.ReadAllAsync(linkedCts.Token))
+            {
+                await WriteEventAsync(writer, message);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("SSE stream cancelled for connection {ConnectionId}", ConnectionId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error streaming SSE for connection {ConnectionId}", ConnectionId);
+        }
+    }
+
+    private static async Task WriteEventAsync(StreamWriter writer, SseMessage message)
+    {
+        if (!string.IsNullOrEmpty(message.Id))
+            await writer.WriteAsync($"id: {message.Id}\n");
+        if (!string.IsNullOrEmpty(message.Event))
+            await writer.WriteAsync($"event: {message.Event}\n");
+
+        // Split data by newlines for SSE format
+        var lines = message.Data.Split('\n');
+        foreach (var line in lines)
+        {
+            await writer.WriteAsync($"data: {line}\n");
+        }
+        await writer.WriteAsync("\n");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _cts.Cancel();
+        _outboundChannel.Writer.TryComplete();
+        _inboundChannel.Writer.TryComplete();
+        _cts.Dispose();
+
+        await Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// SSE message format.
+/// </summary>
+public sealed class SseMessage
+{
+    public string? Id { get; init; }
+    public string? Event { get; init; }
+    public string Data { get; init; } = string.Empty;
+}


### PR DESCRIPTION
This commit enables cloud deployment on Koyeb with full OAuth integration:

## Transport Layer
- Add SSE (Server-Sent Events) transport for MCP protocol
- Support dual-mode: stdio (traditional) or HTTP/SSE (cloud)
- DOCX_MCP_TRANSPORT env var controls mode selection

## Authentication
- Microsoft Entra ID (Azure AD) OAuth 2.0 integration
- JWT Bearer token validation for SSE endpoints
- Development mode with auto-auth for local testing
- Token refresh support via TokenService

## Storage Abstraction
- IStorageProvider interface for pluggable backends
- LocalStorageProvider for filesystem (dev/Docker volumes)
- GcsStorageProvider for Google Cloud Storage
- CloudSessionStore with distributed locking support

## HTTP Endpoints
- GET /health - Health check for Koyeb load balancer
- GET /auth/login - OAuth login initiation
- GET /auth/callback - OAuth callback handler
- GET /sse - SSE connection for MCP protocol
- POST /message - Client-to-server MCP messages

## Koyeb Configuration
- Dockerfile.koyeb optimized for cloud deployment
- koyeb.yaml with secrets and environment configuration
- .env.example documenting all configuration options

https://claude.ai/code/session_01BCtJwfHtV2F9Uz3X2VWnuX

Closes #20