### PR TITLE
perf(ci): parallel native builds + manifest merge

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -44,18 +44,25 @@ jobs:
         run: dotnet test --no-build --configuration Release --verbosity normal
 
   # =============================================================================
-  # Linux Docker Build (Multi-arch)
+  # Linux Docker Build (Native parallel builds + manifest merge)
   # =============================================================================
   docker-linux:
-    name: Docker Linux (amd64 + arm64)
+    name: Docker Linux (${{ matrix.arch }})
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+            platform: linux/amd64
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            platform: linux/arm64
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -78,6 +85,9 @@ jobs:
             org.opencontainers.image.vendor=${{ vars.DOCKERHUB_USERNAME }}
             org.opencontainers.image.licenses=MIT
             org.opencontainers.image.documentation=https://github.com/${{ github.repository }}
+          # Suffix tags with arch for per-arch images
+          flavor: |
+            suffix=-${{ matrix.arch }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -90,15 +100,58 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+  # =============================================================================
+  # Merge multi-arch manifests
+  # =============================================================================
+  docker-manifest:
+    name: Docker Manifest
+    needs: docker-linux
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKERHUB_IMAGE }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' }}
+
+      - name: Create and push manifests
+        run: |
+          # For each tag, create a manifest combining amd64 and arm64
+          for tag in ${{ steps.meta.outputs.tags }}; do
+            echo "Creating manifest for $tag"
+            docker manifest create "$tag" \
+              "${tag}-amd64" \
+              "${tag}-arm64"
+            docker manifest annotate "$tag" "${tag}-amd64" --arch amd64
+            docker manifest annotate "$tag" "${tag}-arm64" --arch arm64
+            docker manifest push "$tag"
+          done
 
       - name: Update Docker Hub README
-        if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
@@ -374,7 +427,7 @@ jobs:
   # =============================================================================
   release:
     name: Create Release
-    needs: [docker-linux, installer-windows, installer-macos]
+    needs: [docker-manifest, installer-windows, installer-macos]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Replace QEMU emulation with native ARM64 runners for Docker builds.
- Build amd64 on ubuntu-latest, arm64 on ubuntu-24.04-arm in parallel
- Merge manifests in separate job after both builds complete
- Should reduce build time from ~22min to ~3-5min

https://claude.ai/code/session_01BPM75USMsX2MkHmNTAjUtp