### PR TITLE
fix(ci): handle multi-line tags in manifest merge script

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -139,9 +139,12 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' }}
 
       - name: Create and push manifests
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
         run: |
           # For each tag, create a manifest combining amd64 and arm64
-          for tag in ${{ steps.meta.outputs.tags }}; do
+          echo "$TAGS" | while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
             echo "Creating manifest for $tag"
             docker manifest create "$tag" \
               "${tag}-amd64" \


### PR DESCRIPTION
Pass tags via env var and read line-by-line to avoid bash syntax errors with tags containing special characters.

https://claude.ai/code/session_01BPM75USMsX2MkHmNTAjUtp