### PR TITLE
fix(ci): filter artifact downloads to exclude buildx cache

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -442,10 +442,17 @@ jobs:
         with:
           fetch-depth: 0  # Fetch all history for tags
 
-      - name: Download all artifacts
+      - name: Download Windows installers
         uses: actions/download-artifact@v4
         with:
           path: artifacts
+          pattern: windows-*-installer
+
+      - name: Download macOS installer
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: macos-*-dmg
 
       - name: Extract version
         id: version


### PR DESCRIPTION
The .dockerbuild artifacts from buildx cache were causing download failures. Filter to only download installer artifacts.

https://claude.ai/code/session_01BPM75USMsX2MkHmNTAjUtp