### PR TITLE
feat(watch): initial diff+import on watch start with import checkpoin…

### DIFF
--- a/src/DocxMcp.Cli/WatchDaemon.cs
+++ b/src/DocxMcp.Cli/WatchDaemon.cs
@@ -63,8 +63,24 @@ public sealed class WatchDaemon : IDisposable
         watcher.Renamed += (_, e) => OnFileRenamed(sessionId, e.OldFullPath, e.FullPath);
         watcher.Deleted += (_, e) => OnFileDeleted(sessionId, e.FullPath);
 
+        // Stop the tracker's internal FSW to avoid dual-watcher race condition.
+        // The daemon will drive change detection via CheckForChanges.
+        _tracker.StopWatching(sessionId);
+        _tracker.EnsureTracked(sessionId);
+
         _watchers[$"{sessionId}:{fullPath}"] = watcher;
         _onOutput($"[WATCH] Watching {fileName} for session {sessionId}");
+
+        // Initial sync — diff + import before watching
+        _onOutput($"[INIT] Running initial sync for {fileName}...");
+        try
+        {
+            ProcessChange(sessionId, fullPath, isImport: true);
+        }
+        catch (Exception ex)
+        {
+            _onOutput($"[WARN] Initial sync failed: {ex.Message}");
+        }
     }
 
     /// <summary>
@@ -100,11 +116,23 @@ public sealed class WatchDaemon : IDisposable
         _watchers[$"folder:{fullPath}"] = watcher;
         _onOutput($"[WATCH] Watching folder {fullPath} for {pattern}");
 
-        // Register existing files
+        // Register existing files and run initial sync
         foreach (var file in Directory.EnumerateFiles(fullPath, pattern,
             includeSubdirectories ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly))
         {
-            TryRegisterExistingFile(file);
+            var registeredSessionId = TryRegisterExistingFile(file);
+            if (registeredSessionId is not null)
+            {
+                _onOutput($"[INIT] Running initial sync for {Path.GetFileName(file)}...");
+                try
+                {
+                    ProcessChange(registeredSessionId, file, isImport: true);
+                }
+                catch (Exception ex)
+                {
+                    _onOutput($"[WARN] Initial sync failed for {Path.GetFileName(file)}: {ex.Message}");
+                }
+            }
         }
     }
 
@@ -135,17 +163,28 @@ public sealed class WatchDaemon : IDisposable
         _cts.Cancel();
     }
 
+    private static bool DebugEnabled =>
+        Environment.GetEnvironmentVariable("DEBUG") is not null;
+
     private void OnFileChanged(string sessionId, string filePath)
     {
+        if (DebugEnabled)
+            _onOutput($"[DEBUG:watch] FSW fired for {Path.GetFileName(filePath)} (session {sessionId})");
+
         // Debounce
         var key = $"{sessionId}:{filePath}";
         var now = DateTime.UtcNow;
         if (_debounceTimestamps.TryGetValue(key, out var last) &&
             (now - last).TotalMilliseconds < _debounceMs)
         {
+            if (DebugEnabled)
+                _onOutput($"[DEBUG:watch] Debounced (last: {(now - last).TotalMilliseconds:F0}ms ago, threshold: {_debounceMs}ms)");
             return;
         }
         _debounceTimestamps[key] = now;
+
+        if (DebugEnabled)
+            _onOutput($"[DEBUG:watch] Scheduling ProcessChange after {_debounceMs}ms debounce");
 
         // Wait for debounce period
         Task.Delay(_debounceMs).ContinueWith(_ =>
@@ -157,29 +196,36 @@ public sealed class WatchDaemon : IDisposable
             catch (Exception ex)
             {
                 _onOutput($"[ERROR] {sessionId}: {ex.Message}");
+                if (DebugEnabled)
+                    _onOutput($"[DEBUG:watch] Exception: {ex}");
             }
         });
     }
 
-    private void ProcessChange(string sessionId, string filePath)
+    private void ProcessChange(string sessionId, string filePath, bool isImport = false)
     {
-        if (_autoSync)
+        if (DebugEnabled)
+            _onOutput($"[DEBUG:watch] ProcessChange called for {Path.GetFileName(filePath)}");
+
+        // Always sync into WAL — watch is meant to keep the session in sync automatically
+        var result = _tracker.SyncExternalChanges(sessionId, isImport: isImport);
+        if (DebugEnabled)
+            _onOutput($"[DEBUG:watch] SyncResult: HasChanges={result.HasChanges}, Message={result.Message}");
+
+        if (result.HasChanges)
         {
-            var result = _tracker.SyncExternalChanges(sessionId);
-            if (result.HasChanges)
+            _onOutput($"[SYNC] {Path.GetFileName(filePath)} (+{result.Summary!.Added} -{result.Summary.Removed} ~{result.Summary.Modified}) WAL:{result.WalPosition}");
+
+            if (result.Patches is { Count: > 0 })
             {
-                _onOutput($"[SYNC] {Path.GetFileName(filePath)}: {result.Message}");
+                var patchesArr = new System.Text.Json.Nodes.JsonArray(
+                    result.Patches.Select(p => (System.Text.Json.Nodes.JsonNode?)System.Text.Json.Nodes.JsonNode.Parse(p.ToJsonString())).ToArray());
+                _onOutput(patchesArr.ToJsonString(new System.Text.Json.JsonSerializerOptions { WriteIndented = true }));
             }
-        }
-        else
-        {
-            var patch = _tracker.CheckForChanges(sessionId);
-            if (patch is not null)
+
+            if (result.UncoveredChanges is { Count: > 0 })
             {
-                _onOutput($"[CHANGE] {Path.GetFileName(filePath)}: " +
-                    $"+{patch.Summary.Added} -{patch.Summary.Removed} ~{patch.Summary.Modified}");
-                _onOutput($"         Change ID: {patch.Id}");
-                _onOutput($"         Use 'sync-external {sessionId}' to sync.");
+                _onOutput($"  Uncovered: {string.Join(", ", result.UncoveredChanges.Select(u => $"[{u.ChangeKind}] {u.Type}"))}");
             }
         }
     }
@@ -239,7 +285,7 @@ public sealed class WatchDaemon : IDisposable
         return null;
     }
 
-    private void TryRegisterExistingFile(string filePath)
+    private string? TryRegisterExistingFile(string filePath)
     {
         var sessionId = FindSessionForFile(filePath);
         if (sessionId is not null)
@@ -247,6 +293,7 @@ public sealed class WatchDaemon : IDisposable
             _tracker.StartWatching(sessionId);
             _onOutput($"[TRACK] {Path.GetFileName(filePath)} -> session {sessionId}");
         }
+        return sessionId;
     }
 
     public void Dispose()

--- a/src/DocxMcp/ExternalChanges/ExternalChangePatch.cs
+++ b/src/DocxMcp/ExternalChanges/ExternalChangePatch.cs
@@ -208,6 +208,9 @@ public sealed class SyncResult
     /// <summary>Position in WAL after sync.</summary>
     public int? WalPosition { get; init; }
 
+    /// <summary>JSON patches representing the body changes.</summary>
+    public List<JsonObject>? Patches { get; init; }
+
     public static SyncResult NoChanges() => new()
     {
         Success = true,
@@ -225,6 +228,7 @@ public sealed class SyncResult
     public static SyncResult Synced(
         DiffSummary summary,
         List<UncoveredChange> uncoveredChanges,
+        List<JsonObject> patches,
         string? acknowledgedChangeId,
         int walPosition)
     {
@@ -239,6 +243,7 @@ public sealed class SyncResult
             HasChanges = true,
             Summary = summary,
             UncoveredChanges = uncoveredChanges,
+            Patches = patches,
             AcknowledgedChangeId = acknowledgedChangeId,
             WalPosition = walPosition,
             Message = $"Synced: +{summary.Added} -{summary.Removed} ~{summary.Modified}{uncoveredMsg}. WAL position: {walPosition}"

--- a/src/DocxMcp/Helpers/ContentHasher.cs
+++ b/src/DocxMcp/Helpers/ContentHasher.cs
@@ -78,7 +78,7 @@ public static class ContentHasher
     /// Strip all ID and revision attributes from an element and its descendants.
     /// Also removes namespace declarations for dmcp namespace to ensure consistent hashing.
     /// </summary>
-    private static void StripIdAttributes(OpenXmlElement element)
+    internal static void StripIdAttributes(OpenXmlElement element)
     {
         // Get all attributes and find ones to remove
         var attributes = element.GetAttributes().ToList();

--- a/src/DocxMcp/Persistence/WalEntry.cs
+++ b/src/DocxMcp/Persistence/WalEntry.cs
@@ -12,7 +12,10 @@ public enum WalEntryType
     Patch = 0,
 
     /// <summary>External sync - document was reloaded from disk.</summary>
-    ExternalSync = 1
+    ExternalSync = 1,
+
+    /// <summary>Import - initial sync when watch starts (diff + import from disk).</summary>
+    Import = 2
 }
 
 /// <summary>

--- a/tests/DocxMcp.Tests/DebugDiffIssues.cs
+++ b/tests/DocxMcp.Tests/DebugDiffIssues.cs
@@ -1,0 +1,304 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using DocxMcp.Diff;
+using DocxMcp.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DocxMcp.Tests;
+
+/// <summary>
+/// Debug tests to verify hypotheses about diff inconsistencies (issue #34).
+/// </summary>
+public class DebugDiffIssues : IDisposable
+{
+    private readonly ITestOutputHelper _output;
+    private readonly List<DocxSession> _sessions = [];
+
+    public DebugDiffIssues(ITestOutputHelper output) => _output = output;
+
+    // ===================================================================
+    // Hypothesis 1: Uncovered changes are false positives from ID attributes
+    // ===================================================================
+
+    [Fact]
+    public void Debug_UncoveredChanges_FalsePositives_FromIdAttributes()
+    {
+        // Create a document with headers and footers
+        var original = CreateDocWithHeaderFooter("Body text", "Header text", "Footer text");
+        _sessions.Add(original);
+
+        // Serialize and reload (simulates sync-external loading from file)
+        var bytes = original.ToBytes();
+        var reloaded = DocxSession.FromBytes(bytes, "test-reload", null);
+        _sessions.Add(reloaded);
+
+        // Now add IDs (simulates what sync-external does with EnsureAllIds)
+        ElementIdManager.EnsureNamespace(reloaded.Document);
+        ElementIdManager.EnsureAllIds(reloaded.Document);
+
+        // Compare original (no IDs) vs reloaded (with IDs)
+        var uncovered = DiffEngine.DetectUncoveredChanges(original.Document, reloaded.Document);
+
+        _output.WriteLine($"Uncovered changes count: {uncovered.Count}");
+        foreach (var uc in uncovered)
+        {
+            _output.WriteLine($"  [{uc.ChangeKind}] {uc.Type}: {uc.Description} ({uc.PartUri})");
+        }
+
+        // HYPOTHESIS: If uncovered changes are from ID attributes, we'll see false positives
+        // for headers/footers even though content is identical
+        if (uncovered.Count > 0)
+        {
+            _output.WriteLine("\n==> CONFIRMED: Uncovered changes are false positives from ID attributes!");
+            _output.WriteLine("    DetectUncoveredChanges compares raw OuterXml including dmcp:id.");
+        }
+        else
+        {
+            _output.WriteLine("\n==> REFUTED: No false positives detected.");
+        }
+    }
+
+    [Fact]
+    public void Debug_UncoveredChanges_WithIdenticalDocuments()
+    {
+        // Compare a document with itself — should show zero uncovered changes
+        var doc = CreateDocWithHeaderFooter("Body", "Header", "Footer");
+        _sessions.Add(doc);
+
+        var uncovered = DiffEngine.DetectUncoveredChanges(doc.Document, doc.Document);
+        _output.WriteLine($"Self-comparison uncovered changes: {uncovered.Count}");
+        Assert.Empty(uncovered);
+    }
+
+    [Fact]
+    public void Debug_UncoveredChanges_ByteRoundtrip_NoIds()
+    {
+        // Round-trip without adding IDs — should show zero uncovered changes
+        var original = CreateDocWithHeaderFooter("Body", "Header", "Footer");
+        _sessions.Add(original);
+
+        var reloaded = DocxSession.FromBytes(original.ToBytes(), "test-noid", null);
+        _sessions.Add(reloaded);
+
+        var uncovered = DiffEngine.DetectUncoveredChanges(original.Document, reloaded.Document);
+        _output.WriteLine($"Round-trip (no IDs) uncovered changes: {uncovered.Count}");
+        foreach (var uc in uncovered)
+        {
+            _output.WriteLine($"  [{uc.ChangeKind}] {uc.Type}: {uc.Description}");
+        }
+    }
+
+    // ===================================================================
+    // Hypothesis 2: Spurious moves from duplicate fingerprints
+    // ===================================================================
+
+    [Fact]
+    public void Debug_SpuriousMoves_AfterSyncSimulation()
+    {
+        // Simulate the bug report scenario:
+        // 1. Create doc with several paragraphs
+        // 2. Modify one paragraph (simulating external edit)
+        // 3. Diff should show 1 modification
+        // 4. "Sync" by replacing session with modified bytes + adding IDs
+        // 5. Diff should show 0 changes
+
+        // Step 1: Create original document
+        var original = CreateSession();
+        var body = original.GetBody();
+        body.AppendChild(CreateParagraph("Bonjour,"));
+        body.AppendChild(CreateParagraph("Caca prout,"));
+        body.AppendChild(CreateParagraph("Je suis titulaire d'une carte de séjour."));
+        body.AppendChild(CreateParagraph("")); // empty paragraph
+        body.AppendChild(CreateParagraph("Cordialement,"));
+        body.AppendChild(CreateParagraph("")); // another empty paragraph
+        body.AppendChild(CreateParagraph("Veuillez trouver ci-joint les pièces."));
+        body.AppendChild(CreateParagraph("")); // yet another empty paragraph
+
+        // Save original to file
+        var originalBytes = original.ToBytes();
+
+        // Step 2: Create modified version (edit paragraph 2)
+        var modified = DocxSession.FromBytes(originalBytes, "mod", null);
+        _sessions.Add(modified);
+        var modBody = modified.GetBody();
+        var para2 = modBody.Elements<Paragraph>().ElementAt(1);
+        // Replace text
+        para2.RemoveAllChildren<Run>();
+        para2.AppendChild(new Run(new Text("Caca prout 2,")));
+
+        var modifiedBytes = modified.ToBytes();
+
+        // Step 3: First diff — should show 1 modification
+        var diff1 = DiffEngine.Compare(originalBytes, modifiedBytes);
+        _output.WriteLine("=== First diff (original vs modified) ===");
+        _output.WriteLine($"Total: {diff1.Summary.TotalChanges}, Modified: {diff1.Summary.Modified}, Moved: {diff1.Summary.Moved}, Added: {diff1.Summary.Added}, Removed: {diff1.Summary.Removed}");
+        foreach (var c in diff1.Changes)
+        {
+            _output.WriteLine($"  [{c.ChangeType}] {c.ElementType} old:{c.OldIndex} new:{c.NewIndex} \"{c.OldText?[..Math.Min(40, c.OldText?.Length ?? 0)]}\" -> \"{c.NewText?[..Math.Min(40, c.NewText?.Length ?? 0)]}\"");
+        }
+
+        // Step 4: Simulate sync-external — load modified bytes, add IDs
+        var synced = DocxSession.FromBytes(modifiedBytes, "synced", null);
+        _sessions.Add(synced);
+        ElementIdManager.EnsureNamespace(synced.Document);
+        ElementIdManager.EnsureAllIds(synced.Document);
+        var syncedBytes = synced.ToBytes();
+
+        // Step 5: Diff synced session vs modified file — should show 0 changes
+        var diff2 = DiffEngine.Compare(syncedBytes, modifiedBytes);
+        _output.WriteLine("\n=== Second diff (synced session vs modified file) ===");
+        _output.WriteLine($"Total: {diff2.Summary.TotalChanges}, Modified: {diff2.Summary.Modified}, Moved: {diff2.Summary.Moved}, Added: {diff2.Summary.Added}, Removed: {diff2.Summary.Removed}");
+        foreach (var c in diff2.Changes)
+        {
+            _output.WriteLine($"  [{c.ChangeType}] {c.ElementType} old:{c.OldIndex} new:{c.NewIndex} \"{c.OldText?[..Math.Min(40, c.OldText?.Length ?? 0)]}\" -> \"{c.NewText?[..Math.Min(40, c.NewText?.Length ?? 0)]}\"");
+        }
+
+        if (diff2.HasChanges)
+        {
+            _output.WriteLine("\n==> BUG CONFIRMED: Spurious changes after sync!");
+        }
+        else
+        {
+            _output.WriteLine("\n==> No spurious changes (bug not reproduced in this scenario).");
+        }
+    }
+
+    [Fact]
+    public void Debug_ExactMatch_DuplicateFingerprints()
+    {
+        // Test exact matching with duplicate empty paragraphs
+        var original = CreateSession();
+        var body = original.GetBody();
+        body.AppendChild(CreateParagraph("A"));
+        body.AppendChild(CreateParagraph("")); // empty para 1
+        body.AppendChild(CreateParagraph("B"));
+        body.AppendChild(CreateParagraph("")); // empty para 2
+        body.AppendChild(CreateParagraph("C"));
+
+        // Modified: same content, same order
+        var modified = CreateSessionFromBytes(original.ToBytes());
+
+        var diff = DiffEngine.Compare(original.Document, modified.Document);
+        _output.WriteLine($"Identical doc with duplicate fingerprints: {diff.Summary.TotalChanges} changes, {diff.Summary.Moved} moves");
+
+        if (diff.Summary.Moved > 0)
+        {
+            _output.WriteLine("==> BUG: Spurious moves for duplicate empty paragraphs!");
+            foreach (var c in diff.Changes.Where(c => c.ChangeType == ChangeType.Moved))
+            {
+                _output.WriteLine($"  Moved: old:{c.OldIndex} new:{c.NewIndex}");
+            }
+        }
+    }
+
+    [Fact]
+    public void Debug_ExactMatch_DuplicateFingerprints_WithInsertion()
+    {
+        // Test with an insertion among duplicates
+        var original = CreateSession();
+        var origBody = original.GetBody();
+        origBody.AppendChild(CreateParagraph("A"));
+        origBody.AppendChild(CreateParagraph("")); // empty para
+        origBody.AppendChild(CreateParagraph("B"));
+        origBody.AppendChild(CreateParagraph("")); // empty para
+
+        var modified = CreateSession();
+        var modBody = modified.GetBody();
+        modBody.AppendChild(CreateParagraph("A"));
+        modBody.AppendChild(CreateParagraph("")); // empty para
+        modBody.AppendChild(CreateParagraph("NEW PARAGRAPH")); // inserted
+        modBody.AppendChild(CreateParagraph("B"));
+        modBody.AppendChild(CreateParagraph("")); // empty para
+
+        var diff = DiffEngine.Compare(original.Document, modified.Document);
+        _output.WriteLine($"With insertion among duplicates: {diff.Summary.TotalChanges} changes");
+        _output.WriteLine($"  Added: {diff.Summary.Added}, Removed: {diff.Summary.Removed}, Modified: {diff.Summary.Modified}, Moved: {diff.Summary.Moved}");
+
+        foreach (var c in diff.Changes)
+        {
+            _output.WriteLine($"  [{c.ChangeType}] {c.ElementType} old:{c.OldIndex} new:{c.NewIndex} \"{c.OldText}\" -> \"{c.NewText}\"");
+        }
+
+        if (diff.Summary.Moved > 0)
+        {
+            _output.WriteLine("==> BUG: Spurious moves when inserting among duplicate elements!");
+        }
+        else if (diff.Summary.Added == 1 && diff.Summary.TotalChanges == 1)
+        {
+            _output.WriteLine("==> CORRECT: Only 1 addition detected.");
+        }
+    }
+
+    // ===================================================================
+    // Helpers
+    // ===================================================================
+
+    private DocxSession CreateSession()
+    {
+        var session = DocxSession.Create();
+        _sessions.Add(session);
+        return session;
+    }
+
+    private DocxSession CreateSessionFromBytes(byte[] bytes)
+    {
+        var session = DocxSession.FromBytes(bytes, Guid.NewGuid().ToString("N")[..12], null);
+        _sessions.Add(session);
+        return session;
+    }
+
+    private static DocxSession CreateDocWithHeaderFooter(string bodyText, string headerText, string footerText)
+    {
+        var ms = new MemoryStream();
+        using (var doc = WordprocessingDocument.Create(ms, WordprocessingDocumentType.Document))
+        {
+            var mainPart = doc.AddMainDocumentPart();
+            mainPart.Document = new Document(new Body(new Paragraph(new Run(new Text(bodyText)))));
+
+            // Add header
+            var headerPart = mainPart.AddNewPart<HeaderPart>();
+            headerPart.Header = new Header(new Paragraph(new Run(new Text(headerText))));
+            headerPart.Header.Save();
+
+            // Add footer
+            var footerPart = mainPart.AddNewPart<FooterPart>();
+            footerPart.Footer = new Footer(new Paragraph(new Run(new Text(footerText))));
+            footerPart.Footer.Save();
+
+            // Reference header/footer in section properties
+            var sectionProps = new SectionProperties();
+            sectionProps.AppendChild(new HeaderReference
+            {
+                Type = HeaderFooterValues.Default,
+                Id = mainPart.GetIdOfPart(headerPart)
+            });
+            sectionProps.AppendChild(new FooterReference
+            {
+                Type = HeaderFooterValues.Default,
+                Id = mainPart.GetIdOfPart(footerPart)
+            });
+            mainPart.Document.Body!.AppendChild(sectionProps);
+            mainPart.Document.Save();
+        }
+
+        ms.Position = 0;
+        return DocxSession.FromBytes(ms.ToArray(), Guid.NewGuid().ToString("N")[..12], null);
+    }
+
+    private static Paragraph CreateParagraph(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return new Paragraph();
+        return new Paragraph(new Run(new Text(text)));
+    }
+
+    public void Dispose()
+    {
+        foreach (var s in _sessions)
+        {
+            try { s.Dispose(); } catch { }
+        }
+    }
+}

--- a/tests/DocxMcp.Tests/DebugDiffIssues2.cs
+++ b/tests/DocxMcp.Tests/DebugDiffIssues2.cs
@@ -1,0 +1,219 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using DocxMcp.Diff;
+using DocxMcp.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DocxMcp.Tests;
+
+/// <summary>
+/// Deeper debugging for diff inconsistencies (issue #34).
+/// </summary>
+public class DebugDiffIssues2 : IDisposable
+{
+    private readonly ITestOutputHelper _output;
+    private readonly List<DocxSession> _sessions = [];
+
+    public DebugDiffIssues2(ITestOutputHelper output) => _output = output;
+
+    // ===================================================================
+    // Why does round-trip change header/footer OuterXml?
+    // ===================================================================
+
+    [Fact]
+    public void Debug_RoundTrip_HeaderXmlDifference()
+    {
+        // Create doc with header, capture OuterXml, round-trip, capture again
+        var ms = new MemoryStream();
+        string originalHeaderXml;
+        string originalFooterXml;
+
+        using (var doc = WordprocessingDocument.Create(ms, WordprocessingDocumentType.Document))
+        {
+            var mainPart = doc.AddMainDocumentPart();
+            mainPart.Document = new Document(new Body(new Paragraph(new Run(new Text("Body")))));
+
+            var headerPart = mainPart.AddNewPart<HeaderPart>();
+            headerPart.Header = new Header(new Paragraph(new Run(new Text("Header text"))));
+            headerPart.Header.Save();
+
+            var footerPart = mainPart.AddNewPart<FooterPart>();
+            footerPart.Footer = new Footer(new Paragraph(new Run(new Text("Footer text"))));
+            footerPart.Footer.Save();
+
+            var sectionProps = new SectionProperties();
+            sectionProps.AppendChild(new HeaderReference
+            {
+                Type = HeaderFooterValues.Default,
+                Id = mainPart.GetIdOfPart(headerPart)
+            });
+            sectionProps.AppendChild(new FooterReference
+            {
+                Type = HeaderFooterValues.Default,
+                Id = mainPart.GetIdOfPart(footerPart)
+            });
+            mainPart.Document.Body!.AppendChild(sectionProps);
+            mainPart.Document.Save();
+
+            originalHeaderXml = headerPart.Header.OuterXml;
+            originalFooterXml = footerPart.Footer.OuterXml;
+        }
+
+        _output.WriteLine("=== ORIGINAL Header XML ===");
+        _output.WriteLine(originalHeaderXml);
+        _output.WriteLine("\n=== ORIGINAL Footer XML ===");
+        _output.WriteLine(originalFooterXml);
+
+        // Round-trip via bytes
+        var bytes = ms.ToArray();
+        using var ms2 = new MemoryStream(bytes);
+        using var doc2 = WordprocessingDocument.Open(ms2, false);
+
+        var reloadedHeaderXml = doc2.MainDocumentPart!.HeaderParts.First().Header!.OuterXml;
+        var reloadedFooterXml = doc2.MainDocumentPart!.FooterParts.First().Footer!.OuterXml;
+
+        _output.WriteLine("\n=== RELOADED Header XML ===");
+        _output.WriteLine(reloadedHeaderXml);
+        _output.WriteLine("\n=== RELOADED Footer XML ===");
+        _output.WriteLine(reloadedFooterXml);
+
+        var headersMatch = originalHeaderXml == reloadedHeaderXml;
+        var footersMatch = originalFooterXml == reloadedFooterXml;
+
+        _output.WriteLine($"\nHeaders match: {headersMatch}");
+        _output.WriteLine($"Footers match: {footersMatch}");
+
+        if (!headersMatch)
+        {
+            _output.WriteLine("\n==> Header XML changed during round-trip!");
+            _output.WriteLine($"Original length: {originalHeaderXml.Length}");
+            _output.WriteLine($"Reloaded length: {reloadedHeaderXml.Length}");
+        }
+        if (!footersMatch)
+        {
+            _output.WriteLine("\n==> Footer XML changed during round-trip!");
+            _output.WriteLine($"Original length: {originalFooterXml.Length}");
+            _output.WriteLine($"Reloaded length: {reloadedFooterXml.Length}");
+        }
+    }
+
+    // ===================================================================
+    // Harder attempts to reproduce spurious moves
+    // ===================================================================
+
+    [Fact]
+    public void Debug_SpuriousMoves_WithIdsOnOneSide()
+    {
+        // The real scenario: one document has dmcp:ids, the other doesn't
+        var original = CreateSession();
+        var body = original.GetBody();
+        body.AppendChild(CreateParagraph("Bonjour,"));
+        body.AppendChild(CreateParagraph("Caca prout,"));
+        body.AppendChild(CreateParagraph("Je suis titulaire."));
+        body.AppendChild(CreateParagraph(""));
+        body.AppendChild(CreateParagraph("Cordialement,"));
+        body.AppendChild(CreateParagraph(""));
+        body.AppendChild(CreateParagraph("Veuillez trouver."));
+        body.AppendChild(CreateParagraph(""));
+
+        // Add IDs to original (simulates MCP session)
+        ElementIdManager.EnsureNamespace(original.Document);
+        ElementIdManager.EnsureAllIds(original.Document);
+        var sessionBytes = original.ToBytes();
+
+        // Create modified version WITHOUT IDs (simulates external file)
+        var fileDoc = CreateSession();
+        var fileBody = fileDoc.GetBody();
+        fileBody.AppendChild(CreateParagraph("Bonjour,"));
+        fileBody.AppendChild(CreateParagraph("Caca prout 2,"));  // modified
+        fileBody.AppendChild(CreateParagraph("Je suis titulaire."));
+        fileBody.AppendChild(CreateParagraph(""));
+        fileBody.AppendChild(CreateParagraph("Cordialement,"));
+        fileBody.AppendChild(CreateParagraph(""));
+        fileBody.AppendChild(CreateParagraph("Veuillez trouver."));
+        fileBody.AppendChild(CreateParagraph(""));
+        var fileBytes = fileDoc.ToBytes();
+
+        // Diff: session (with IDs) vs file (without IDs)
+        var diff1 = DiffEngine.Compare(sessionBytes, fileBytes);
+        _output.WriteLine("=== Diff: session(+IDs) vs file(-IDs) ===");
+        _output.WriteLine($"Total: {diff1.Summary.TotalChanges}, Modified: {diff1.Summary.Modified}, Moved: {diff1.Summary.Moved}, Added: {diff1.Summary.Added}");
+        foreach (var c in diff1.Changes)
+        {
+            _output.WriteLine($"  [{c.ChangeType}] old:{c.OldIndex} new:{c.NewIndex} \"{Trunc(c.OldText)}\" -> \"{Trunc(c.NewText)}\"");
+        }
+
+        // Now simulate sync: load file bytes, add IDs, save
+        var synced = DocxSession.FromBytes(fileBytes, "synced", null);
+        _sessions.Add(synced);
+        ElementIdManager.EnsureNamespace(synced.Document);
+        ElementIdManager.EnsureAllIds(synced.Document);
+        var syncedBytes = synced.ToBytes();
+
+        // Diff: synced session (with new IDs) vs file (without IDs)
+        var diff2 = DiffEngine.Compare(syncedBytes, fileBytes);
+        _output.WriteLine("\n=== Diff: synced(+newIDs) vs file(-IDs) ===");
+        _output.WriteLine($"Total: {diff2.Summary.TotalChanges}, Modified: {diff2.Summary.Modified}, Moved: {diff2.Summary.Moved}, Added: {diff2.Summary.Added}");
+        foreach (var c in diff2.Changes)
+        {
+            _output.WriteLine($"  [{c.ChangeType}] old:{c.OldIndex} new:{c.NewIndex} \"{Trunc(c.OldText)}\" -> \"{Trunc(c.NewText)}\"");
+        }
+    }
+
+    [Fact]
+    public void Debug_Fingerprints_WithAndWithoutIds()
+    {
+        // Check if fingerprints change when dmcp:id is added
+        var para1 = new Paragraph(new Run(new Text("Hello")));
+        var snap1 = ElementSnapshot.FromElement(para1, 0, "/body");
+
+        // Same paragraph with dmcp:id
+        var para2 = new Paragraph(new Run(new Text("Hello")));
+        ElementIdManager.SetDmcpId(para2, "12345678");
+        var snap2 = ElementSnapshot.FromElement(para2, 0, "/body");
+
+        _output.WriteLine($"Without ID - Fingerprint: {snap1.Fingerprint}, Text: \"{snap1.Text}\"");
+        _output.WriteLine($"With ID    - Fingerprint: {snap2.Fingerprint}, Text: \"{snap2.Text}\"");
+        _output.WriteLine($"Fingerprints match: {snap1.Fingerprint == snap2.Fingerprint}");
+
+        // Empty paragraphs
+        var empty1 = new Paragraph();
+        var snapE1 = ElementSnapshot.FromElement(empty1, 0, "/body");
+        var empty2 = new Paragraph();
+        ElementIdManager.SetDmcpId(empty2, "ABCDEF01");
+        var snapE2 = ElementSnapshot.FromElement(empty2, 0, "/body");
+
+        _output.WriteLine($"\nEmpty without ID - Fingerprint: {snapE1.Fingerprint}, Text: \"{snapE1.Text}\"");
+        _output.WriteLine($"Empty with ID    - Fingerprint: {snapE2.Fingerprint}, Text: \"{snapE2.Text}\"");
+        _output.WriteLine($"Empty fingerprints match: {snapE1.Fingerprint == snapE2.Fingerprint}");
+    }
+
+    // ===================================================================
+    // Helpers
+    // ===================================================================
+
+    private DocxSession CreateSession()
+    {
+        var session = DocxSession.Create();
+        _sessions.Add(session);
+        return session;
+    }
+
+    private static Paragraph CreateParagraph(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return new Paragraph();
+        return new Paragraph(new Run(new Text(text)));
+    }
+
+    private static string Trunc(string? s) =>
+        s is null ? "" : s.Length > 40 ? s[..37] + "..." : s;
+
+    public void Dispose()
+    {
+        foreach (var s in _sessions)
+            try { s.Dispose(); } catch { }
+    }
+}


### PR DESCRIPTION
…t naming

- Add WalEntryType.Import (= 2) for initial sync entries
- Add ImportCheckpointPath ({sessionId}.import.{position}.docx) to SessionStore
- Use PersistImportCheckpoint for Import entries in SessionManager.AppendExternalSync
- LoadNearestCheckpoint checks import paths first, then regular checkpoint paths
- DeleteCheckpoints/DeleteCheckpointsAfter clean up both checkpoint types
- Add isImport parameter to ExternalChangeTracker.SyncExternalChanges
- WatchDaemon.WatchFile runs initial sync before realtime watching begins
- WatchDaemon.WatchFolder runs initial sync for all tracked files after registration
- Update Redo, GetHistory, GetLastExternalSyncHash to handle Import entry type